### PR TITLE
Add newlines after headers in RFC template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -4,16 +4,19 @@
 - Sway Issue: [FueLabs/sway#0000](https://github.com/FuelLabs/Sway/issues/0000)
 
 # Summary
+
 [summary]: #summary
 
 One paragraph explanation of the feature.
 
 # Motivation
+
 [motivation]: #motivation
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
 # Guide-level explanation
+
 [guide-level-explanation]: #guide-level-explanation
 
 Explain the proposal as if it was already included in the language and you were teaching it to another Sway programmer. That generally means:
@@ -28,6 +31,7 @@ Explain the proposal as if it was already included in the language and you were 
 For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
 
 # Reference-level explanation
+
 [reference-level-explanation]: #reference-level-explanation
 
 This is the technical portion of the RFC. Explain the design in sufficient detail that:
@@ -40,11 +44,13 @@ This is the technical portion of the RFC. Explain the design in sufficient detai
 The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
 
 # Drawbacks
+
 [drawbacks]: #drawbacks
 
 Why should we *not* do this?
 
 # Rationale and alternatives
+
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 - Why is this design the best in the space of possible designs?
@@ -52,6 +58,7 @@ Why should we *not* do this?
 - What is the impact of not doing this?
 
 # Prior art
+
 [prior-art]: #prior-art
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
@@ -69,6 +76,7 @@ Note that while precedent set by other languages is some motivation, it does not
 Please also take into consideration that rust sometimes intentionally diverges from common language features.
 
 # Unresolved questions
+
 [unresolved-questions]: #unresolved-questions
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
@@ -76,6 +84,7 @@ Please also take into consideration that rust sometimes intentionally diverges f
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
 # Future possibilities
+
 [future-possibilities]: #future-possibilities
 
 Think about what the natural extension and evolution of your proposal would


### PR DESCRIPTION
Since this is how we want things formatted, the template should be updated as well.