### PR TITLE
Configurable and composable storage

### DIFF
--- a/files/0013-configurable-and-composable-storage/api-design/storage_encoded_box.sw
+++ b/files/0013-configurable-and-composable-storage/api-design/storage_encoded_box.sw
@@ -1,0 +1,91 @@
+// This example shows how to apply the proposed API design guidelines
+// on the `StorageEncodedBox`.
+//
+// For API design quidelines, see `api-design/storage_vec.sw`.
+//
+// For the complete `Storage` implementation of the `StorageEncodedBox` and its other aspects
+// see `sway-libs/storage/storage_encoded_box.sw`.
+//--
+
+impl StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    //--
+    // Reading can fail so we provide `try_read` and `read`.
+    //--
+    #[storage(read)]
+    fn try_read(&self) -> Option<T> {
+        let encoded_value = /* ...
+           Read the length of the encoded value from the `self_key`
+           and continue reading the `u8` content from the slots.
+           If any of the reads fail, the `try_read` fails.
+
+           The implementation uses `storage::internal::read(<key>)`
+           to actually read from the storage.
+           ...
+        */;
+
+        Some(abi_decode::<T>(encoded_value))
+    }
+
+    #[storage(read)]
+    fn read(&self) -> T {
+        self.try_read().unwrap()
+    }
+
+    //--
+    // Write cannot fail so we provide only `write`.
+    //
+    // Since the content can have a variable length, in case of writing,
+    // the default implementation will just overwrite the old value,
+    // potentially leaving parts of the old content in the storage
+    // (if it was longer then the new value).
+    //
+    // Thus, to enable clearing of the old content, we provide the
+    // `write_deep_clear` method.
+    //--
+    #[storage(write)]
+    fn write(&mut self, value: &T) {
+        let encoded_value = encode::<T>(value);
+
+        /* ...
+           Write the length of the `encoded_value` to the `self.self_key`
+           and continue writing its packed `u8` content to that and
+           the consecutive slots.
+
+           Packing also means packing 8 `u8`s into a single `u64`
+           and then those `u64`s into slots.
+
+           The implementation uses `storage::internal::write(<key>, <val>)`
+           to actually write to the storage.
+           ...
+        */
+    }
+
+    #[storage(write)]
+    fn write_deep_clear(&mut self, value: &T) {
+        let encoded_value = encode::<T>(value);
+
+        /* ...
+           Write the new content, and clear the remaining parts of the old
+           content, if any.
+           ...
+        */
+    }
+
+    //--
+    // Clear always means a semantic clear with a minimum storage manipulation. In the case
+    // of the `StorageEncodedBox`, it is sufficient to clear the slot at its self key.
+    //
+    // Note that we do not have the `clear_deep_clear` equivalent. We expect here to use
+    // the `deep_clear` method directly.
+    //--
+    #[storage(write)]
+    fn clear(&mut self) {
+        /* ...
+           Clear only the slot at the `self_key` by calling the `storage::internal::clear::<T>(<key>)`
+           where `T` is a type that guarantees a single slot gets cleared.
+           
+           TODO-DISCUSSION: See the discussion on clearing API in the `internal.sw`.
+           ...
+        */
+    }
+}

--- a/files/0013-configurable-and-composable-storage/api-design/storage_pair.sw
+++ b/files/0013-configurable-and-composable-storage/api-design/storage_pair.sw
@@ -1,0 +1,92 @@
+// This example shows how to apply the proposed API design guidelines
+// on the `StoragePair`.
+//
+// For API design quidelines, see `api-design/storage_vec.sw` and `api-design/storage_encoded_box.sw`.
+//
+// For the complete `Storage` implementation of the `StoragePair` and its other aspects
+// see `sway-libs/storage/storage_pair.sw`.
+//--
+
+impl<A, B> StoragePair<A, B> where A: Storage, B: Storage {
+    const fn get_first_element_self_key(self_key: &StorageKey) -> StorageKey {
+        //--
+        // Returns the self key of the first element of the pair.
+        // `self_key` is the self key of the `StoragePair`.
+        // For the sample implementation, see `sway-libs/user-defined-libs/storage_vec.sw`.
+        //--
+    }
+
+    /// Returns the self key of the second element of the pair.
+    /// `self_key` is the self key of the [StoragePair].
+    const fn get_snd_element_self_key(self_key: &StorageKey) -> StorageKey {
+        //--
+        // Returns the self key of the second element of the pair.
+        // `self_key` is the self key of the `StoragePair`.
+        // For the sample implementation, see `sway-libs/user-defined-libs/storage_vec.sw`.
+        //--
+    }
+
+    //--
+    // The below methods consistently apply the API guidelines
+    // exaplained in detail in `api-design/storage_vec.sw` and `api-design/storage_encoded_box.sw`.
+    //--
+
+    #[storage(read)]
+    pub const fn first(&self) -> A {
+        A::new(Self::get_first_element_self_key(&self.self_key))
+    }
+
+    #[storage(read)]
+    pub const fn snd(&self) -> B {
+        B::new(Self::get_snd_element_self_key(&self.self_key))
+    }
+
+    #[storage(write)]
+    pub fn set_first(&mut self, value: &A::Value) -> A {
+        let first_element_self_key = Self::get_first_element_self_key(&self.self_key);
+        A::init(&first_element_self_key, value)
+    }
+
+    #[storage(write)]
+    pub fn set_first_deep_clear(&mut self, value: &A::Value) -> A where A: DeepClearStorage {
+        let first_element_self_key = Self::get_first_element_self_key(&self.self_key);
+        self.set_element_deep_clear::<A>(&first_element_self_key, value)
+    }
+
+    #[storage(write)]
+    pub fn set_snd(&mut self, value: &B::Value) -> B {
+        let snd_element_self_key = Self::get_snd_element_self_key(&self.self_key);
+        A::init(&snd_element_self_key, value)
+    }
+
+    #[storage(write)]
+    pub fn set_snd_deep_clear(&mut self, value: &B::Value) -> B where B: DeepClearStorage {
+        let snd_element_self_key = Self::get_snd_element_self_key(&self.self_key);
+        self.set_element_deep_clear::<B>(&first_element_self_key, value)
+    }
+
+    #[storage(write)]
+    fn set_element_deep_clear<TElement>(element_self_key: &StorageKey, value: &TElement::Value) -> TElement where TElement: DeepClearStorage {
+        match TElement::internal_layout() {
+            // If the size of the element is fixed, we will just overwrite the current content, if any.
+            ContinuousOfKnownSize(_) => { },
+            // Otherwise, we must first deep clear the content.
+            _ => TElement::new(element_self_key).deep_clear(),
+        }
+
+        TElement::init(element_self_key, value)
+    }
+
+    #[storage(write)]
+    pub fn clear(&mut self) {
+        /* ...
+           Clear only the slot at the `self_key` by calling the `storage::internal::clear::<T>(<key>)`
+           where `T` is a type that guarantees a single slot gets cleared.
+           
+           TODO-DISCUSSION: See the discussion on clearing API in the `internal.sw`.
+           ...
+        */
+    }
+
+    /* ... Other `StoragePair` methods that follow the same API design guidelines. ... */
+}

--- a/files/0013-configurable-and-composable-storage/api-design/storage_vec.sw
+++ b/files/0013-configurable-and-composable-storage/api-design/storage_vec.sw
@@ -1,0 +1,173 @@
+//--
+// This example discuss details of the proposed API design guidelines
+// in respect to:
+//  - handling uninitialized `Storage`.
+//  - handling semantic errors in operations.
+//  - handling special options like, e.g., skipping checks for performance.
+//
+// For the complete `Storage` implementation of the `StorageVec` and its other aspects
+// see `sway-libs/storage/storage_vec.sw`.
+//--
+
+impl<T> StorageVec<T> where T: Storage {
+    const fn get_element_self_key(self_key: &StorageKey, element_index: u64) -> StorageKey {
+        //--
+        // Calcualte the self key of the element stored at `element_index`.
+        // `self_key` is the self key of the [StorageVec].
+        // For the sample implementation, see `sway-libs/storage/storage_vec.sw`.
+        //--
+    }
+
+    //--
+    // Getting length can fail if the `StorageVec` is not initialized.
+    // Therefore, we provide the `try` method.
+    // `try` methods return `Option`.
+    //--
+    #[storage(read)]
+    pub fn try_len(&self) -> Option<u64> {
+        storage::internal::read::<u64>(self.self_key)
+    }
+
+    //--
+    // For every `try` method, we provide its "non-try" equivalent,
+    // which just unwraps the result of the `try` methods.
+    // Therefore, it reverts if the `StorageVec` is uninitialized.
+    //--
+    #[storage(read)]
+    pub fn len(&self) -> u64 {
+        self.try_len().unwrap()
+    }
+
+    //--
+    // For each `Storage`, we give an uninitialize storage a semantic
+    // meaning. In the case of the `StorageVec`, we treat the uninitialized
+    // `StorageVec` as an empty `StorageVec`.
+    //
+    // This means that the `push` cannot fail, and therefore, we provide only
+    // the `push` method, an not a `try_push`.
+    //--
+    #[storage(write)]
+    pub fn push(&mut self, value: &T::Value) {
+        let len = self.try_len().unwrap_or(0);
+
+        // Store the value.
+        let element_self_key = Self::get_element_self_key(&self.self_key, len);
+        T::init(element_self_key, value);
+
+        // Store the new length.
+        storage::internal::write(self.self_key, len + 1);
+    }
+
+    //--
+    // `pop` is a much more difficult example.
+    // Same as with `push` and other methods, we treat an uninitialized
+    // `StorageVec` as an empty vector.
+    //
+    // The additional challange here is providing the possibility to deep clear
+    // the popped element. This surely requires an separate method because of
+    // an additional trait constraint `T: DeepClearStorage`.
+    //
+    // In this case, the guideline is to provide a `<name>_<special_behavior>()`
+    // equivalent, `pop_deep_clear()`.
+    //
+    // So we will have a `pop` and a `pop_deep_clear` methods.
+    //
+    // Note that this approach, `<name>_<special_behavior>()`, does not scale
+    // well if we want to combine several "special behaviors" in one call.
+    // However, in the storage API design, we do not expect such cases, or at
+    // least not a considerable number of them.
+    //
+    // And in the case they do appear, the guideline is to have a single distinguished
+    // method with a "special behavior" that accepts additional parameters.
+    // E.g., let's say that we want to `<operation>_deep_clear` with certains checks
+    // being optional. A possible method would look like:
+    //
+    //  fn <operation>_deep_clear(&mut self, checked: bool)
+    //--
+    #[storage(write)]
+    pub fn pop(&mut self) -> bool {
+        let len = self.try_len().unwrap_or(0);
+
+        if len <= 0 {
+            return false;
+        }
+
+        //--
+        // Just store the new length, without deep clearing the value.
+        //--
+        storage::internal::write(self.self_key, len - 1);
+    }
+
+    #[storage(write)]
+    pub fn pop_deep_clear(&mut self) -> bool where T: DeepClearStorage {
+        let len = self.try_len().unwrap_or(0);
+
+        if len <= 0 {
+            return false;
+        }
+
+        let element_self_key = Self::get_element_self_key(&self.self_key, len - 1);
+        T::new(element_self_key).deep_clear();
+
+        storage::internal::write(self.self_key, len - 1);
+    }
+
+    //--
+    // Same as above, `get` treats the uninitialized `StorageVec` as empty.
+    //
+    // The important consequence of that decision, to treat an initialized vector
+    // as empty is, that we do not distinguish between "technical" errors, those
+    // coming from reading uninitialized storge, and "semantic" errors, those coming
+    // from, e.g., reading out of bounds.
+    //
+    // This means that we will, following the guideline given above, have a
+    // `try_get` and a `get` method, where actually the `try_get` corresponds to
+    // the `get` method in the current implementation of the `StorageVec`, that
+    // returns `Option`.
+    //--
+    #[storage(read)]
+    pub fn try_get(&self, element_index) -> Option<T> {
+        if self.try_len().unwrap_or(0) <= index {
+            return None;
+        }
+
+        let element_self_key = Self::get_element_self_key(&self.self_key, element_index);
+        Some(T::new(element_self_key))
+    }
+
+    #[storage(read)]
+    pub fn get(&self, element_index) -> T {
+        self.try_get(element_index).unwrap()
+    }
+
+    //--
+    // Another important aspect of `get` is a possibility to have a special behavior
+    // that is not the default one. Concretely, providing the possibility to skip
+    // the costly bound check. According to the `<name>_<special_behavior>` guideline
+    // given above, we will have the `get_unchecked` method.
+    //
+    // Note that in this case, there is no `try_get_unchecked` because ignoring the
+    // boundary check also removes the possibility that the `get` fails.
+    //
+    // In a general case, we should also provide the `try_<name>_<special_behavior>` method.
+    //--
+    #[storage(read)]
+    pub fn get_unchecked(&self, element_index) -> T {
+        let element_self_key = Self::get_element_self_key(&self.self_key, element_index);
+        T::new(element_self_key)
+    }
+
+    //--
+    // Clear always means a semantic clear with a minimum storage manipulation. In the case
+    // of the `StorageVec`, it is sufficient to set its length to zero, or to clear
+    // the slot at its self key.
+    //
+    // Note that we do not have the `clear_deep_clear` equivalent. We expect here to use
+    // the `deep_clear` method directly.
+    //--
+    pub fn clear(&mut self) {
+        storage::internal::write(self.self_key, 0);
+    }
+
+    /* ... Other `StorageVec` methods that follow the same API design guidelines. ... */
+}

--- a/files/0013-configurable-and-composable-storage/contracts/demo_contract_basic_storage.sw
+++ b/files/0013-configurable-and-composable-storage/contracts/demo_contract_basic_storage.sw
@@ -1,0 +1,188 @@
+contract;
+
+abi Demo {
+    #[storage(write)]
+    fn demo();
+}
+
+struct Struct {
+    x: u64,
+    y: bool,
+}
+
+storage {
+    //--
+    // Compiler calls `internal_get_config` here and passes the `:=`'s RHS and the self-generated `StorageKey`.
+    //
+    // There is no any special syntax on the RHS. It's just a regular Sway expression that can occure anywhere
+    // else in Sway that creates a value of the type specified in the declaration of the LHS.
+    //--
+    //--
+    // TODO-DISCUSSION: Is there any better proposal for the "configured with" operator, than `:=`?
+    //                  We do not want to use `=` here because it implies assignment and initialization.
+    //                  Also, we want to use the same operator when configuring configurables.
+    //--
+    box_1: StorageBox<u64> := 0,
+    box_2: StorageBox<u64> := the_meaning_of_life(),
+
+    box_3: StorageBox<Struct> := Struct::default(),
+    box_4: StorageBox<Struct> := Struct { x: 11, y: false },
+    box_4: StorageBox<Struct> := some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"),
+
+    vec_of_val_1: StorageVec<StorageBox<u64>> := [],
+    vec_of_val_2: StorageVec<StorageBox<u64>> := [1, 2, 3, 4, 5],
+    vec_of_val_3: StorageVec<StorageBox<Struct>> := [
+        Struct::default(),
+        Struct { x: 11, y: false },
+        some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"),
+    ],
+
+    vec_of_vec_1: StorageVec<StorageVec<StorageBox<Struct>>> := [
+        [],
+        [Struct::default()],
+        [
+            Struct::default(),
+            Struct { x: 11, y: false },
+            some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"),
+        ]
+    ],
+
+    map_01: StorageMap<str[3], StorageVec<StorageMap<u64, StorageVec<StorageBox<Struct>>>>> := [
+        ("abc", [
+            (11, [Struct::default(), Struct { x: 11, y: false }]),
+            (22, []),
+            (33, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"), Struct::default()]),
+        ]),
+        ("def", [
+            (111, [Struct::default(), Struct { x: 111, y: true }]),
+            (222, [Struct::new_false(222)]),
+            (333, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc")]),
+        ]),
+    ],
+
+    //--
+    // If developers are not interested in configuring storage elements in the code, but just defining them,
+    // they can omit the `:=` operator if the type expected on the RHS implements `core::default::Default` trait.
+    //--
+    default_built_in: StorageBox<u64>,                                     // Same as `default_built_in: StorageBox<u64> := 0`.
+    default_struct: StorageBox<Struct>,                                    // `Struct` implements `core::default::Default`.
+    default_storage_vec: StorageVec<StorageBox<u64>>,                      // Slices implement `Default` and the default is an empty slice `[]`.
+    default_storage_map: StorageMap<str[3], StorageVec<StorageBox<u64>>>,  // Slices implement `Default` and the default is an empty slice `[]`.
+}
+
+impl Demo for Contract {
+    #[storage(write)]
+    fn demo() {
+        //-----------------------------------
+
+        // When creating the `box_1` the compiler calls `new` and passes the self-generated `StorageKey`.
+        let x = storage.box_1.read();
+
+        // `storage` elements are mutable by default.
+        // Important because we properly model mutability on the `Storage` methods.
+        // E.g., `fn write(&mut self)`.
+        storage.box_1.write(&1111);
+
+        // Storage types can also be created and used in code without being declared in the storage.
+        // We assume below that we've calculated the desired `slot` and the `offset` and got the storage key.
+        let storage_key = get_storage_key( ... );
+
+        let local_box_1 = StorageBox::<b256>::init(storage_key, &b256::zero());
+        assert_eq(local_box_1.read(), 0x0000000000000000000000000000000000000000000000000000000000000000);
+
+        // We properly model mutability, so the `local_box_2` must
+        // be mutable if we want to write to the storage through it.
+        let mut local_box_2 = StorageBox::init(storage_key, &true);
+        assert_eq(local_box_2.read(), true);
+
+        local_box_2.write(false);
+        assert_eq(local_box_2.read(), false);
+
+        //-----------------------------------
+
+        assert_eq(storage.vec_of_val_1.len(), 0);
+
+        storage.vec_of_val_1.push(&1111);
+        assert_eq(storage.vec_of_val_1.len(), 1);
+
+        let popped = storage.vec_of_val_1.pop();
+        assert_eq(popped, true);
+
+        storage.vec_of_val_1.push(&2222);
+
+        // The result of `get` is always the stored `Storage`.
+        let val = storage.vec_of_val_1.get(0).read();
+        assert_eq(val, 2222);
+
+        // `StorageVec` implements `DeepReadStorage` and provides
+        // optimized access if the entire stored value is needed.
+        // Should be used rarely and with caution.
+        let content = storage.vec_of_val_1.deep_read();
+        assert_eq(content, [2222])
+
+        storage.vec_of_vec_1.push(&[]);
+        storage.vec_of_vec_1.push(&[Struct { x: 11, y: true }, Struct { x: 22, y: false }]);
+
+        let val = storage.vec_of_vec_1.get(1).get(0).read(); // Accessing `vec_of_vec_1[1][0]`.
+        assert_eq(val, Struct::default());
+
+        let storage_key = get_storage_key( ... );
+
+        let mut local_vec_of_vec_of_vec_1 = StorageVec<StorageVec<StorageVec<StorageBox<u64>>>>::init(storage_key, &[
+            [],
+            [[]],
+            [[], []],
+            [[11, 22, 33], [33, 22, 11]]
+        ]);
+
+        // The overall Storage API prohibits semantically wrong usage.
+        // The desired composition semantics that implies ownership of the
+        // stored data is imposed by the API.
+        //
+        // E.g., `StorageVec::push` does not accept the contained storage
+        // as the type but rather the value that needs to be contained.
+        //
+        // This prohibits non-sensical usage like:
+        //
+        // let vec_of_vec_a = StorageVec<StorageVec<StorageBox<u6>>>::init(...);
+        // let vec_of_vec_b = StorageVec<StorageVec<StorageBox<u6>>>::init(...);
+        // let element_of_a = a.get(0);
+        // vec_of_vec_of_b.push(element_of_a);
+        //
+        // `StorageVec` which is contained in `a` cannot be contained in `b`!
+        //
+        // `StorageRef` allows referencing storage. For the demo see: demo_contract_storage_refs.sw.
+
+        local_vec_of_vec_of_vec_1.push(&[[11, 22, 33], [33, 22, 11]]);
+
+        //-----------------------------------
+
+        let storage_key = get_storage_key( ... );
+
+        let local_map_1 = StorageMap<str[3], StorageVec<StorageMap<u64, StorageVec<StorageBox<Struct>>>>>::init(storage_key, &[]);
+        local_map_1.insert("123", &[
+            ("000", []),
+            ("111", [
+                (111, [Struct::default()]),
+            ]),
+        ]);
+
+        let storage_key = get_storage_key( ... );
+
+        let local_map_2 = StorageMap<str[3], StorageVec<StorageMap<u64, StorageVec<StorageBox<Struct>>>>>::init(storage_key, &[
+            ("abc", [
+                (11, [Struct::default(), Struct { x: 11, y: false }]),
+                (22, []),
+                (33, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true}, "abc"), Struct::default()]),
+            ]),
+            ("def", [
+                (111, [Struct::default(), Struct { x: 111, y: true }]),
+                (222, [Struct::new_false(222)]),
+                (333, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true}, "abc")]),
+            ]),
+        ]);
+
+        let val = local_map_2.get("abc").get(0).get(11).get(0).read();
+        assert_eq(val, Struct::default());
+    }
+}

--- a/files/0013-configurable-and-composable-storage/contracts/demo_contract_encoded_storage.sw
+++ b/files/0013-configurable-and-composable-storage/contracts/demo_contract_encoded_storage.sw
@@ -1,0 +1,90 @@
+contract;
+
+abi Demo {
+    #[storage(write)]
+    fn demo();
+}
+
+struct Struct {
+    vec: Vec<u64>,
+    txt: String,
+}
+
+impl AbiEncode for Struct {
+    fn abi_encode(&self, buffer: Buffer) -> Buffer {
+        let mut buffer = self.vec.abi_encode(buffer);
+        buffer = self.txt.abi_encode(buffer);
+
+        buffer
+    }
+}
+
+impl AbiDecode for Struct {
+    fn abi_decode(ref mut buffer: BufferReader) -> Self {
+        let vec = Vec::<u64>::abi_decode(buffer);
+        let txt = String::abi_decode(buffer);
+
+        Struct {
+            vec,
+            txt,
+        }
+    }
+}
+
+storage {
+    //--
+    // For the sake of example, in the below examples we assume that the `Vec` and `String` have
+    // the presented `const fn from(...)` functions implemented via the `From` trait.
+    // But in general, any const eval expression that returns `Vec`, or `String`, or `Struct` can
+    // apear on the RHS of `:=`.
+    //--
+    //--
+    // The usage patterns and the capabilities of `StorageEncodedBox` are the same as the
+    // ones of the `StorageBox`. Essentially, to support types that require encoding, the only
+    // thing that developers need to do is replace `StorageBox` with `StorageEncodedBox`.
+    //--
+    box_1: StorageEncodedBox<Struct> := Struct::default(),
+    box_2: StorageEncodedBox<Struct> := Struct { vec: Vec::from([1, 2, 3]), txt: String::from("text") },
+    box_3: StorageEncodedBox<Vec<Struct>> := Vec::from([const_create_struct(1, "abc"), const_create_struct(2, "cdf")]),
+
+    vec_of_encoded_val_1: StorageVec<StorageEncodedBox<Vec<bool>> := [Vec::from([true, false, true]), Vec::default(), Vec::from([true])],
+    vec_of_encoded_val_2: StorageVec<StorageEncodedBox<String>> := [String::from("abc"), String::from("cdf")],
+    vec_of_encoded_val_3: StorageVec<StorageEncodedBox<Struct>> := [
+        Struct::default(),
+        Struct { vec: Vec::from([1, 2, 3]), txt: String::from("text") },
+        some_const_fn_that_creates_struct(true, "abc"),
+    ],
+
+    vec_of_vec_1: StorageVec<StorageVec<StorageEncodedBox<Struct>>> := [
+        [],
+        [Struct::default()],
+        [
+            Struct::default(),
+            Struct { vec: Vec::from([1, 2, 3]), txt: String::from("text") },
+            some_const_fn_that_creates_struct(true, "abc"),
+        ]
+    ],
+
+    map_01: StorageMap<str[3], StorageVec<StorageMap<u64, StorageVec<StorageEncodedBox<Struct>>>>> := [
+        ("abc", [
+            (11, [Struct::default(), const_create_struct(1, "abc")]),
+            (22, []),
+            (33, [some_const_fn_that_creates_struct(true, Struct::default()]),
+        ]),
+        ("def", [
+            (111, [Struct::default(), const_create_struct(1, "abc")]),
+            (222, [Struct { vec: Vec::from([1, 2, 3]), txt: String::from("text") }]),
+            (333, [some_const_fn_that_creates_struct(true, "abc")]),
+        ]),
+    ],
+}
+
+impl Demo for Contract {
+    #[storage(write)]
+    fn demo() {
+        //--
+        // `StorageEncodedBox` is used in the code in the same way as the `StorageBox`.
+        // For examples, see `demo_contract_basic_storage.sw`.
+        //--
+    }
+}

--- a/files/0013-configurable-and-composable-storage/contracts/demo_contract_storage_references.sw
+++ b/files/0013-configurable-and-composable-storage/contracts/demo_contract_storage_references.sw
@@ -1,0 +1,71 @@
+contract;
+
+abi Demo {
+    #[storage(write)]
+    fn demo();
+}
+
+type StVecOfU64 = StorageVec<StorageBox<u64>>;
+type StPairOfStVecOfU64 = StoragePair<StVecOfU64, StVecOfU64>;
+
+storage {
+    vec_1: StVecOfU64 := [11, 22, 33],
+    vec_2: StVecOfU64 := [44, 55, 66],
+
+    pair_1: StPairOfStVecOfU64 := ([0, 0, 0], [1, 1, 1]),
+    pair_2: StPairOfStVecOfU64 := ([], []),
+
+    map_1: StorageMap<str[3], StVecOfU64> := [
+        ("abc", [1, 2, 3]),
+        ("def", [11, 22, 33]),
+        ("ghi", [111, 222, 333]),
+    ]
+
+    //--
+    // Storage references can be used in storage configurations.
+    // They can reference other storage elements, or their parts.
+    //
+    // This is possible, because `Storage::new` used to instantiate
+    // storage elements is a `const fn`. So is the `as_ref` which
+    // returns the `StorageRef<Self>`.
+    //--
+    vec_of_refs: StorageVec<StorageRefBox<StVecOfU64>> := [
+        StorageRef::Null,
+        storage.vec_1.as_ref(), // We can reference the whole `StorageVec` but not individual elements,
+                                // because `StorageVec::get` is not a `const fn`.
+        storage.pair_1.first().as_ref(), // `StoragePair::first` is a `const fn`.
+        storage.map_1.get("abc").as_ref(), // `StorageMap::get` is a `const fn`.
+        StorageRef::Ref(some_const_fn_that_returns_the_storage_key_of_the_referenced_storage()),
+    ],
+
+    pair_of_refs: StoragePair<StorageRefBox<StVecOfU64>, StorageRefBox<StVecOfU64>> := (StorageRef::Null, StorageRef::Null),
+}
+
+impl Demo for Contract {
+    #[storage(write)]
+    fn demo() {
+        //--
+        // Storage references can be tested for null or dereferenced
+        // to access the referenced storage elements.
+        //--
+        assert(vec_of_refs.get(0).read().is_null());
+
+        match vec_of_refs.get(1).read().try_deref() {
+            Some(vec_of_u64) => {
+                assert_eq(vec_of_u64.get(0).read(), 11);
+            }
+            _ => { },
+        }
+
+        //--
+        // They can also be set to reference storage elements.
+        // To obtain a `StorageRef` from a `Storage`, use `Storage::as_ref`.
+        //--
+        assert(pair_of_refs.first().read().is_null());
+
+        pair_of_refs.set_first(pair_1.snd().as_ref());
+
+        let referrenced_vec = pair_of_refs.first().read().deref();
+        assert_eq(referrenced_vec.get(0).read(), 1);
+    }
+}

--- a/files/0013-configurable-and-composable-storage/contracts/demo_contract_user_defined_storage.sw
+++ b/files/0013-configurable-and-composable-storage/contracts/demo_contract_user_defined_storage.sw
@@ -1,0 +1,63 @@
+contract;
+
+abi Demo {
+    #[storage(write)]
+    fn demo();
+}
+
+struct Struct {
+    x: u64,
+    y: bool,
+}
+
+type StVecOfU64 = StorageVec<StorageBox<u64>>;
+type StPairOfStVecOfU64 = StoragePair<StVecOfU64, StVecOfU64>;
+
+storage {
+    //--
+    // Every user-defined `Storage` is fully compatible with SDK and all other storage types.
+    // Implementing `Storage` automatically makes any `Storage` configurable and composable.
+    //--
+    pair_1: StoragePair<StorageBox<u64>, StorageEncodedBox<String>> := (123, String::from("text")),
+    pair_2: StoragePair<StVecOfU64, StVecOfU64> := ([1, 2, 3], [11, 22, 33]),
+
+    vec_of_pairs: StorageVec<StoragePair<StorageBox<Struct>, StVecOfU64>> := [
+        (Struct { x: 0, y: true }, [1, 2, 3]),
+        (Struct::default(), []),
+        (Struct { x: 11, y: false }, [111, 222, 333]),
+    ],
+
+    map_of_pairs: StorageMap<str[3], StoragePair<StorageBox<Struct>, StVecOfU64>> := [
+        ("abc", (Struct { x: 0, y: true }, [1, 2, 3])),
+        ("def", Struct::default(), []),
+        ("ghi", Struct { x: 11, y: false }, [111, 222, 333]),
+    ],
+
+    pair_of_pairs: StoragePair<StPairOfStVecOfU64, StPairOfStVecOfU64> := (
+        ([1, 2, 3], [11, 22, 33]),
+        ([4, 5, 6], [44, 55, 66])
+    )
+}
+
+impl Demo for Contract {
+    #[storage(write)]
+    fn demo() {
+        assert_eq(pair_1.first().read(), 123);
+
+        pair_1.set_snd(String::from("other text"));
+        assert_eq(pair_1.snd().read(), String::from("other text"));
+
+        // Storage types can also be created and used in code without being declared in the storage.
+        // We assume below that we've calculated the desired `slot` and the `offset` and got the storage key.
+        let storage_key = get_storage_key( ... );
+
+        let mut local_pair_1 = StoragePair::<StPairOfStVecOfU64, StPairOfStVecOfU64>::init(&storage_key,
+            (([], []), ([], []))
+        );
+        
+        local_pair_1.first().snd().push(123);
+
+        let local_pair_1_value = local_pair_1.deep_read();
+        asert_eq(local_pair_1_value, (([], [123]), ([], [])));
+    }
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage.sw
@@ -1,0 +1,245 @@
+//--
+// Unlike the current `StorageKey`, the new one becomes a plain struct that holds
+// the `slot` and the `offset`. There will be no storage type impls on it.
+//--
+pub struct StorageKey {
+    slot: b256,
+    offset: u64,
+}
+
+impl StorageKey {
+    pub const fn new(slot: b256, offset: u64) -> Self {
+        Self {
+            slot,
+            offset
+        }
+    }
+}
+
+/// Defines how a concrete [Storage] implementation places
+/// its stored values within the storage, relative to the
+/// given self key of the storage.
+pub enum StorageLayout {
+    /// The values are scattered within the storage and
+    /// can be on arbitrary storage slots, unrelated to
+    /// the self key.
+    Scattered: (),
+    /// The values are stored starting from the self key
+    /// in a continuous sequence of consecutive storage
+    /// slots. The size that the stored value occupies is
+    /// not know and can vary.
+    Continuous: (),
+    /// The values are stored starting from the self key
+    /// in a continuous sequence of consecutive storage
+    /// slots. The size that the stored value occupies is
+    /// known and fixed.
+    ContinuousOfKnownSize: u64,
+}
+
+//--
+// Functions and methods marked with `internal` are used only by Storage
+// implementors and by the compiler.
+//
+// TODO-DISCUSSION: Should we introduce a language feature here and not rely on a naming convention hack?
+//                  E.g., a language feature for something like `pub(impl) fn`.
+//                  The naming convention solution is convenient and simple, but still bloats the list
+//                  of methods/functions availabe in a scope.
+//--
+pub trait Storage {
+    /// The type of the value that can be stored in this [Storage].
+    type Value;
+    /// The type that describes how this [Storage] stores its internal data and the
+    /// stored value within the storage.
+    ///
+    /// This type can be only one of the valid combinations of [StorageConfig<TValue>]s described below.
+    ///
+    /// Sway compiler will use this type to properly configure storage slots for the elements declared
+    /// in `storage` declarations.
+    ///
+    /// `Config` type is defined recursively as:
+    ///
+    /// ```ignore
+    /// <Config> := StorageConfig<TValue>
+    ///             | [<Config>]
+    ///             | (<Config>, ...);
+    /// ```
+    ///
+    /// Where `[<Config>]` represents a slice of `Config`s and `(<Config>, ...)` a tuple of arbitrary
+    /// many `Config`s.
+    type Config;
+
+    /// Creates a new [Storage] that is not initialized.
+    ///
+    /// To create a new initialized [Storage], use the [Storage::init] constructor.
+    //--
+    //  Compiler will call this function in the storage element access.
+    //  E.g. in `storage.x` to create `x`.
+    //
+    //  Note that `new` is a `const` function. This allows us to use storage
+    //  elements when configuring other storage elements, e.g., to obtain
+    //  storage references within storage configuration. For an example,
+    //  see `demo_contract_storage_references.sw`.
+    //--
+    const fn new(self_key: &StorageKey) -> Self;
+
+    /// Creates a configuration information for configuring an instance of this [Storage].
+    /// The [Storage] will be located at the `self_key` and has to store `values`.
+    ///
+    /// This function should be used only when developing a custom
+    /// [Storage] and should never occur in contract code.
+    //--
+    //  Compiler will call this function when generating storage slots.
+    //  It will pass the `self_key` that it has generated for the storage element
+    //  and the `value` will be the the const evaluated configuration value
+    //  defined at the RHS of the `:=` operator.
+    //--
+    const fn internal_get_config(self_key: &StorageKey, value: &Self::Value) -> Self::Config;
+
+    /// The [StorageLayout] of this [Storage].
+    ///
+    /// This function should be used only when developing a custom
+    /// [Storage] and should never occur in contract code.
+    const fn internal_layout() -> StorageLayout;
+
+    /// The self key of this [Storage].
+    const fn self_key(&self) -> StorageKey;
+
+    /// Creates a new [Storage] that is initialized to the `value`.
+    /// The created [Storage] is located at the `self_key` and stores the `value`.
+    //--
+    // TODO-DISCUSSION: Should we pass the `&Self::Value` here or just the `Self::Value`?
+    //                  This is a general question that is not only related to the storage API.
+    //                  It will become relevant when we introduce references in the STD.
+    //                  It is about avoiding copying data but not having the move semantics.
+    //                  How much can we optimize? How to avoid heap allocations in case of
+    //                  using references? Etc.
+    //--
+    #[storage(write)]
+    fn init(self_key: &StorageKey, value: &Self::Value) -> Self;
+} {
+    const fn as_ref(&self) -> StorageRef<Self> {
+        StorageRef::<Self>::Ref(self.self_key())
+    }
+}
+
+/// Provides information to the compiler, during the configuration of the `storage`,
+/// at which `storage_key` to store the `value`.
+///
+/// `TValue` cannot be a [Storage] or a [StorageConfig].
+///
+/// This struct should be used only when developing a custom
+/// [Storage] and should never occur in contract code.
+pub struct StorageConfig<TValue>
+{
+    pub storage_key: StorageKey,
+    pub value: TValue,
+}
+
+/// Stores a reference to a [Storage] of type `TStorage`.
+///
+/// To create a [StorageRef::Ref] use [Storage::as_ref].
+///
+/// To create a null reference, use [StorageRef::Null].
+///
+/// Internally, a [StorageRef] stores the storage key
+/// of the referenced storage entity.
+///
+/// [StorageRef] requires two storage slots to store a reference.
+/// Consider using other, less storage consuming, approaches to "reference"
+/// storage entities. E.g., if they are stored in a [StorageVec], consider
+/// "referencing" them by storing their indices as "references".
+//--
+// This type is a type safe wrapper around `StorageKey` that
+// ensures we are always referencing and dereferencing a
+// proper `TStorage` type.
+//--
+pub enum StorageRef<TStorage> where TStorage: Storage {
+    Null: (),
+    Ref: StorageKey,
+}
+
+impl<TStorage> StorageRef<TStorage> where TStorage: Storage {
+    /// Reverts if the [StorageRef] is [StorageRef::Null].
+    fn deref(&self) -> TStorage {
+        self.try_deref().unwrap()
+    }
+
+    const fn try_deref(&self) -> Option<TStorage> {
+        match self {
+            Self::Null => None,
+            Self::Ref(storage_key) => Some(TStorage::new(storage_key)),
+        }
+    }
+
+    const fn is_null(&self) -> bool {
+        match self {
+            Self::Null => true,
+            _ => false,
+        }
+    }
+}
+
+/// A [Storage] that supports reading and retrieving its entire stored value.
+pub trait DeepReadStorage: Storage {
+    /// Returns the entired value stored in the [Storage],
+    /// or `None` if the [Storage] is uninitialized.
+    ///
+    /// Composable storage types usually offer specialized
+    /// methods for accessing parts of the stored value.
+    /// Retrieving the entire stored value should be used
+    /// only if the entire value is actually needed.
+    ///
+    /// Not all storage types can retrieve the value
+    /// they store. E.g., a [StorageMap] is not aware of
+    /// all the elements stored and require access by
+    /// key to individual elements.
+    ///
+    /// Retrieving the entire stored value can require
+    /// high amout of storage reads for certain storage
+    /// types. Therefore, this method must always be
+    /// used with care and only if the entire value is
+    /// actually needed.
+    #[storage(read)]
+    fn try_deep_read(&self) -> Option<Self::Value>;
+} {
+    #[storage(read)]
+    fn deep_read(&self) -> Self::Value {
+        self.try_deep_read().unwrap()
+    }
+}
+
+/// A [Storage] that supports removing its entire stored value
+/// from the storage by uninitializing the storage slots which
+/// were occupied by the stored value.
+pub trait DeepClearStorage: Storage {
+    /// Clears the entired value stored in the [Storage].
+    ///
+    /// This call always succeeds, even if the [Storage] is
+    /// uninitialized.
+    ///
+    /// Composable storage types usually offer specialized
+    /// methods for semantically clear the stored value.
+    /// To clear semantically means that the value will be removed
+    /// from the perspective of the storage type, but the
+    /// occupied storage slots will not necessarily be uninitialized.
+    ///
+    /// E.g., semantically clearing a [StorageVec] could simply set the length
+    /// of the vector to zero, without actually touching the stored
+    /// elements.
+    ///
+    /// Clearing the entire stored value should be used
+    /// only if clearing the entire value is actually needed.
+    ///
+    /// Not all storage types can clear the value
+    /// they store. E.g., a [StorageMap] is not aware of
+    /// all the elements stored and therefore cannot clear
+    /// all of them.
+    ///
+    /// Clearing the entire stored value can require
+    /// high amout of storage clears for certain storage
+    /// types. Therefore, this method must always be
+    /// used with care and only if clearing the entire value is
+    /// actually needed.
+    #[storage(write)]
+    fn deep_clear(&mut self);
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/internal.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/internal.sw
@@ -1,0 +1,38 @@
+//! This module contains functions for low-level storage access.
+//! These functions should be used only when developing a custom
+//! [Storage] and should never occur in a contract code.
+
+// TODO-DISCUSSION: See the comment on `Serializable` in the `storage_box.sw`.
+use core::marker::Serializable;
+
+#[storage(write)]
+pub fn write<T>(storage_key: &StorageKey, value: &T)
+where T: Serializable
+{
+    //--
+    // Here comes the same implementation as in the current `std::storage::storage_api::write`.
+    //--
+}
+
+#[storage(read)]
+pub fn read<T>(storage_key: &StorageKey) -> Option<T>
+    where T: Serializable 
+{ 
+    //--
+    // Here comes the same implementation as in the current `std::storage::storage_api::read`.
+    //--
+}
+
+//--
+// TODO-DISCUSSION: Should we also provide a function for clearing a certain number of elements of
+//                  the type `T`? This would, e.g., easy clearing a known number of bytes.
+//                  Also a dedicated function for clearing the slot, e.g., `clear_slot(<key>)`.
+//--
+#[storage(write)]
+pub fn clear<T>(storage_key: &StorageKey) -> bool
+    where T: Serializable 
+{
+    //--
+    // Here comes the same implementation as in the current `std::storage::storage_api::clear`.
+    //--
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_box.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_box.sw
@@ -1,0 +1,96 @@
+// TODO-DISCUSSION: How to call the marker trait that marks the types that are, in Rust terms, Sized, and
+//                  does not contain pointers or references?
+//                  We want to storage-box only the types that can be safely memcopyed.
+//                  Note that this trait is not the same as `Copy`, because the `Copy` trait can be
+//                  manually implemented and this is a marker trait given by the compiler.
+use core::marker::Serializable;
+
+pub struct StorageBox<T> where T: Serializable {
+    self_key: StorageKey,
+}
+
+//--
+// A `StorageBox` cannot contain other `Storage`s.
+// `StorageBox` is the atomic storage type. It is the leaf
+// of any hierarchy of composed storages. Thinking of an arbitrary
+// storage type as a recursive hierarchy of contained storage types,
+// `StorageBox` is what stops the recursion. It cannot be broken
+// into smaller `Storage` types.
+//
+// To convey that in the Sway language the proposal is to use "negative impls".
+// See: https://doc.rust-lang.org/beta/unstable-book/language-features/negative-impls.html
+//--
+impl<T> !Storage for StorageBox<T> where T: Storage { }
+
+impl<T> Storage for StorageBox<T> where T: Serializable {
+    type Value = T;
+    type Config = StorageConfig<T>;
+
+    const fn new(self_key: &StorageKey) -> Self {
+        Self {
+            self_key: *self_key
+        }
+    }
+
+    const fn internal_get_config(self_key: &StorageKey, value: &T) -> StorageConfig<T> {
+        StorageConfig {
+            self_key: *self_key,
+            value: *value,
+        }
+    }
+
+    const fn internal_layout() -> StorageLayout {
+        StorageLayout::ContinuousOfKnownSize(__size_of::<T>())
+    }
+
+    const fn self_key(&self) -> StorageKey {
+        self.self_key
+    }
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, value: &T) -> Self {
+        storage::internal::write(self_key, value);
+        Self::new(self_key)
+    }
+}
+
+//--
+// For the detailed API design guidelines see the examples in the `api-design`.
+//--
+
+impl<T> StorageBox<T> where T: Serializable {
+    /// Reverts if the [StorageBox] is uninitialized.
+    #[storage(read)]
+    fn read(&self) -> T {
+        self.try_read().unwrap()
+    }
+
+    #[storage(read)]
+    fn try_read(&self) -> Option<T> {
+        storage::internal::read::<T>(self.self_key)
+    }
+
+    #[storage(write)]
+    fn write(&mut self, value: &T) {
+        storage::internal::write(self.self_key, value);
+    }
+
+    #[storage(write)]
+    fn clear(&mut self) {
+        storage::internal::clear::<T>(self.self_key);
+    }
+}
+
+impl<T> DeepReadStorage for StorageBox<T> where T: Serializable {
+    #[storage(read)]
+    fn try_deep_read(&self) -> Option<T> {
+        self.try_read()
+    }
+}
+
+impl<T> DeepClearStorage for StorageBox<T> where T: Serializable {
+    #[storage(write)]
+    fn deep_clear(&mut self) {
+        self.clear()
+    }
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_encoded_box.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_encoded_box.sw
@@ -1,0 +1,149 @@
+/// Atomic [Storage] type that encodes the value it stores
+/// using the value's type implementation of [AbiEncode].
+///
+/// The [StorageEncodedBox] is used for storing dynamic types
+/// like, e.g., `Vec` or `String`, or any user-defined type that is not
+/// [core::marker::Serializable] but implements [AbiEncode]
+/// and [AbiDecode].
+pub struct StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    self_key: StorageKey,
+}
+
+//--
+// `StorageEncodedBox` is another one atomic storage type.
+// The idea and the reasoning behind atomic storage types
+// as well as negative impls is explained in the `storage_box.sw`.
+//--
+impl<T> !Storage for StorageEncodedBox<T> where T: Storage { }
+
+//--
+// TODO-DISCUSSION: See discussion on `Serializable` in the `storage_box.sw`.
+//--
+use core::marker::Serializable;
+
+//--
+// TODO-DISCUSSION: Shell we forbid encoded-boxing serializable types and thus force
+//                  them to be boxed in `StorageBox` or should this only be a compiler warning?
+//                  Essentially, if a type is `Serializable` encoding it unnecessarily
+//                  is a huge waste of computational and storage resources.
+//--
+
+impl<T> !Storage for StorageEncodedBox<T> where T: Serializable { }
+
+impl<T> Storage for StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    type Value = T;
+    //--
+    // The assumption is, once we get slices, `raw_slice` will dissapear. 
+    // Today this would be a `StorageConfig<raw_slice>`.
+    //--
+    type Config = StorageConfig<[u8]>; 
+
+    const fn new(self_key: &StorageKey) -> Self {
+        Self {
+            self_key: *self_key
+        }
+    }
+
+    const fn internal_get_config(self_key: &StorageKey, value: &T) -> StorageConfig<T> {
+        StorageConfig {
+            self_key: *self_key,
+            //--
+            // Note that we assume that the `encode` will be defined as:
+            //   pub const fn encode<T>(item: &T) -> [u8]
+            //--
+            value: encode::<T>(value),
+        }
+    }
+
+    const fn internal_layout() -> StorageLayout {
+        StorageLayout::Continuous
+    }
+
+    const fn self_key(&self) -> StorageKey {
+        self.self_key
+    }
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, value: &T) -> Self {
+        let mut new_box = Self::new(self_key);
+        new_box.write(value);
+        new_box
+    }
+}
+
+//--
+// For the detailed API design guidelines see the examples in the `api-design`.
+//--
+
+impl StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    /// Reverts if the [StorageEncodedBox] is uninitialized.
+    #[storage(read)]
+    fn read(&self) -> T {
+        self.try_read().unwrap()
+    }
+
+    #[storage(read)]
+    fn try_read(&self) -> Option<T> {
+        let encoded_value = /* ...
+           Read the length of the encoded value from the `self_key`
+           and continue reading the `u8` content from the slots.
+           If any of the reads fail, the `try_read` fails.
+
+           The implementation uses `storage::internal::read(<key>)`
+           to actually read from the storage.
+           ...
+        */;
+
+        Some(abi_decode::<T>(encoded_value))
+    }
+
+    #[storage(write)]
+    fn write(&mut self, value: &T) {
+        let encoded_value = encode::<T>(value);
+
+        /* ...
+           Write the length of the `encoded_value` to the `self.self_key`
+           and continue writing its packed `u8` content to that and
+           the consecutive slots.
+
+           Packing also means packing 8 `u8`s into a single `u64`
+           and then those `u64`s into slots.
+
+           The implementation uses `storage::internal::write(<key>, <val>)`
+           to actually write to the storage.
+           ...
+        */
+    }
+
+    #[storage(write)]
+    fn clear(&mut self) {
+        /* ...
+           Clear only the slot at the `self_key` by calling the `storage::internal::clear::<T>(<key>)`
+           where `T` is a type that guarantees a single slot gets cleared.
+           
+           TODO-DISCUSSION: See the discussion on clearing API in the `internal.sw`.
+           ...
+        */
+    }
+}
+
+impl<T> DeepReadStorage for StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    #[storage(read)]
+    fn try_deep_read(&self) -> Option<T> {
+        self.try_read()
+    }
+}
+
+impl<T> DeepClearStorage for StorageEncodedBox<T> where T: AbiEncode + AbiDecode {
+    #[storage(write)]
+    fn deep_clear(&mut self) -> Option<T> {
+        /* ...
+           Read the length of the `encoded_value` and calculate the
+           optimal (minimal) number of calls to `storage::internal::clear(<key>)`
+           needed to clear the entire value from the storage.
+           
+           TODO-DISCUSSION: See the discussion on clearing API in the `internal.sw`.
+           ...
+        */
+    }
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_map.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_map.sw
@@ -1,0 +1,91 @@
+//--
+// We assume here that slices will have const eval implementations for:
+//  - `[T] += [T] -> [T]`: slice contatenation.
+//  - `[T] += T   -> [T]`: extending a slice with an element.
+//--
+pub struct StorageMap<K, V> where K: Hash, V: Storage {
+    self_key: StorageKey,
+}
+
+//--
+// The key of a `StorageMap` cannot be a `Storage`.
+// We forbid this by negative impls, essentially saying that
+// a StorageMap whose key is a Storage is not a Storage itself.
+//--
+//--
+// TODO-DISCUSSION: Should we in general prevent that Storage implements Hash?
+//                  Or on the contrary allow it and allow here that `K` can be
+//                  a `Storage` as long as it implements `Hash`?
+//                  It is difficult, though, to imagine a `Storage` that implements
+//                  a `const Hash`.
+//--
+impl<K, V> !Storage for StorageMap<K, V> where K: Storage + Hash, V: Storage { }
+
+impl<K, V> Storage for StorageMap<K, V> where K: Hash, V: Storage {
+    type Value = [(K, V::Value)];
+    type Config = [V::Config];
+
+    const fn new(self_key: &StorageKey) -> Self {
+        Self {
+            self_key: *self_key
+        }
+    }
+
+    const fn internal_get_config(self_key: &StorageKey, elements: &[(K, V::Value)]) -> Self::Config {
+        let elements_config: [V::Config] = [];
+        let mut i = 0;
+        while i < elements.len() {
+            let element_self_key = Self::get_element_self_key(&self_key, elements[i].0);
+            elements_config += T::internal_get_config(&element_self_key, &elements[i].1);
+
+            i += 1;
+        }
+
+        elements_config
+    }
+
+    const fn internal_layout() -> StorageLayout {
+        StorageLayout::Scattered
+    }
+
+    const fn self_key(&self) -> StorageKey {
+        self.self_key
+    }
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, elements: &[(K, V::Value)]) -> Self {
+        let mut i = 0;
+        while i < elements.len() {
+            let element_self_key = Self::get_element_self_key(&self_key, elements[i].0);
+            T::init(element_self_key, &elements[i].1);
+
+            i += 1;
+        }
+
+        Self::new(self_key)
+    }
+}
+
+//--
+// For the detailed API design guidelines see the examples in the `api-design`.
+//--
+
+impl<K, V> StorageMap<K, V> where K: Hash, V: Storage {
+    /// Returns the self key of the element stored at `element_key`.
+    /// `self_key` is the self key of the [StorageVec].
+    const fn get_element_self_key(self_key: &StorageKey, element_key: K) -> StorageKey {
+        StorageKey::new(__sha256((*self_key, element_key)), 0);
+    }
+
+    #[storage(write)]
+    pub fn insert(&mut self, key: K, value: &V:Value) -> V {
+        let element_self_key = Self::get_element_self_key(&self_key, key);
+        V:init(element_self_key, value)
+    }
+
+    #[storage(read)]
+    pub const fn get(&self, key: K) -> V {
+        let element_self_key = Self::get_element_self_key(&self_key, key);
+        V:new(element_self_key)
+    }
+}

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_ref_box.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_ref_box.sw
@@ -1,0 +1,9 @@
+//--
+// `StorageRefBox` is just a type alias for the `StorageBox<StorageRef<TStorage>>`.
+// To declare it as such, we need a possibility to declare type aliases with generic parameters
+// and trait constraints.
+//
+// Note that we can always implement it without type aliases with generic parameters,
+// by simply replicating the implementation of the `StorageBox`.
+//--
+pub type StorageRefBox<TStorage> = StorageBox<StorageRef<TStorage>> where TStorage: Storage;

--- a/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_vec.sw
+++ b/files/0013-configurable-and-composable-storage/sway-libs/storage/storage_vec.sw
@@ -1,0 +1,223 @@
+//--
+// We assume here that slices will have const eval implementations for:
+//  - `[T] += [T] -> [T]`: slice contatenation.
+//  - `[T] += T   -> [T]`: extending a slice with an element.
+//--
+pub struct StorageVec<T> where T: Storage {
+    self_key: StorageKey,
+}
+
+impl<T> Storage for StorageVec<T> where T: Storage {
+    type Value = [T::Value];
+    /// The `Config` is a tuple containing the storage configuration
+    /// for the length of the [StorageVec], and the configurations
+    /// for the stored elements.
+    type Config = (StorageConfig<u64>, [T::Config]);
+
+    const fn new(self_key: &StorageKey) -> Self {
+        Self {
+            self_key: *self_key
+        }
+    }
+
+    const fn internal_get_config(self_key: &StorageKey, elements: &[T::Value]) -> Self::Config {
+        // The length is stored at the `self_key`.
+        let length_config = StorageConfig {
+            storage_key: self_key,
+            value: elements.len(),
+        };
+
+        let elements_config: [T::Config] = [];
+        let mut i = 0;
+        while i < elements.len() {
+            let element_self_key = Self::get_element_self_key(&self_key, i);
+            elements_config += T::internal_get_config(&element_self_key, &elements[i]);
+
+            i += 1;
+        }
+
+        (length_config, elements_config)
+    }
+
+    const fn internal_layout() -> StorageLayout {
+        match T::internal_layout() {
+            StorageLayout::Scattered | StorageLayout::Continuous => StorageLayout::Scattered,
+            StorageLayout::ContinuousOfKnownSize(_) => StorageLayout::Continuous,
+        }
+    }
+
+    const fn self_key(&self) -> StorageKey {
+        self.self_key
+    }
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, elements: &[T::Value]) -> Self {
+        // Store the length at the `self_key`.
+        storage::internal::write(self_key, elements.len());
+
+        let mut i = 0;
+        while i < elements.len() {
+            let element_self_key = Self::get_element_self_key(&self_key, i);
+            T::init(&element_self_key, &elements[i]);
+
+            i += 1;
+        }
+
+        Self::new(self_key)
+    }
+}
+
+//--
+// For the detailed API design guidelines see the examples in the `api-design`.
+//--
+
+impl<T> StorageVec<T> where T: Storage {
+    /// Returns the self key of the element stored at `element_index`.
+    /// `self_key` is the self key of the [StorageVec].
+    const fn get_element_self_key(self_key: &StorageKey, element_index: u64) -> StorageKey {
+        match T::internal_layout() {
+            StorageLayout::Scattered | StorageLayout::Continuous => {
+                // The elements are stored each in its own slot.
+                StorageKey::new(__sha256((*self_key, element_index)), 0);
+            }
+            StorageLayout::ContinuousOfKnownSize(element_size) => {
+                //--
+                // The elements are packed and aligned to optimize slot usage and storage access.
+                // Here we calculate the element storage key based on the packing and aligning.
+                //--
+                StorageKey::new(<result of the calculation>);
+            }
+        }
+    }
+
+    /// Reverts if the [StorageVec] is uninitialized.
+    #[storage(read)]
+    pub fn len(&self) -> u64 {
+        self.try_len().unwrap()
+    }
+
+    #[storage(read)]
+    pub fn try_len(&self) -> Option<u64> {
+        storage::internal::read::<u64>(self.self_key)
+    }
+
+    #[storage(write)]
+    pub fn push(&mut self, value: &T::Value) {
+        let len = self.try_len().unwrap_or(0);
+
+        // Store the value.
+        let element_self_key = Self::get_element_self_key(&self.self_key, len);
+        T::init(element_self_key, value);
+
+        // Store the new length.
+        storage::internal::write(self.self_key, len + 1);
+    }
+
+    /// Removes the last element of the [StorageVec] and returns true if there was a removal,
+    /// or false if the vector was empty or uninitialized.
+    ///
+    /// To get the last element before popping it use [StorageVec::last].
+    //--
+    // TODO-DISCUSSION: Should we offer a method that pops and returnes the popped value?
+    //                  This could be achieved with a `pop_deep_read` method defined as:
+    //
+    //                     pub fn pop_deep_read(&mut self) -> Option<T::Value> where T: DeepReadStorage
+    //
+    //                  The issue with such a method would be the failing semantic.
+    //                  What to do if popping is possible, but the deep read fails?
+    //                  We could defined it as reverting in that case and not popping.
+    //
+    //                  AS in other cases we then need to offer the `try` equivalent.
+    //                  E.g., `pop_try_deep_read` with a cumbersome returning type of `Option<Option<T::Value>>`.
+    //                  In that case we could successfuly pop even if the deep read fails.
+    //
+    //                  The current `pop` API returns the popped value, but in a broken manner.
+    //                  The gain of having that feature in the new API is questionable.
+    //                  Just calling `StorageVec::last` before calling `pop` seams much simpler,
+    //                  although it departs from the Rust and Sway `Vec` counterparts.
+    //                  We have to bare in mind, though, that storage APIs are specific.
+    //--
+    #[storage(write)]
+    pub fn pop(&mut self) -> bool {
+        let len = self.try_len().unwrap_or(0);
+
+        if len <= 0 {
+            return false;
+        }
+
+        // Store the new length.
+        storage::internal::write(self.self_key, len - 1);
+    }
+
+    #[storage(read)]
+    pub fn get(&self, element_index) -> T {
+        self.try_get(element_index).unwrap()
+    }
+
+    /// Gets the [Storage] stored at the `element_index`, or `None` if index is out of bounds
+    /// or the [StorageVec] is uninitialized.
+    #[storage(read)]
+    pub fn try_get(&self, element_index) -> Option<T> {
+        if self.try_len().unwrap_or(0) <= index {
+            return None;
+        }
+
+        let element_self_key = Self::get_element_self_key(&self.self_key, element_index);
+        Some(T::new(element_self_key))
+    }
+
+    /* ... Other `StorageVec` methods. ... */
+}
+
+impl<T> DeepReadStorage for StorageVec<T> where T: DeepReadStorage {
+    /// Returns the entire content stored within the [StorageVec],
+    /// or `None` if the [StorageVec] or any of the contained [Storage]s
+    //  are uninitialized.
+    ///
+    /// This method can result in multiple storage reads and must,
+    /// therefore, be used with caution and only if the entire content
+    /// is actually needed.
+    #[storage(read)]
+    fn try_deep_read(&self) -> Option<Self::Value> {
+        let len = match self.try_len() {
+            Some(len) => len,
+            None => return None,
+        };
+
+        let result: Self::Value = [];
+        let mut i = 0;
+        while i < len {
+            let element_self_key = Self::get_element_self_key(&self.self_key, i);
+            match T::new(element_self_key).try_deep_read() {
+                Some(value) => {
+                    result += value;
+                }
+                None => return None,
+            }
+
+            i += 1;
+        }
+
+        Some(result)
+    }
+}
+
+impl<T> DeepClearStorage for StorageVec<T> where T: DeepClearStorage {
+    /// Clears the entire content stored within the [StorageVec].
+    ///
+    /// This method can result in multiple storage reads and writes and must,
+    /// therefore, be used with caution and only if clearing the entire content
+    /// is actually needed.
+    #[storage(read, write)]
+    fn deep_clear(&mut self) {
+        let len = match self.try_len().unwrap_or(0);
+
+        let mut i = 0;
+        while i < len {
+            let element_self_key = Self::get_element_self_key(&self.self_key, i);
+            T::new(element_self_key).deep_clear();
+
+            i += 1;
+        }
+    }
+}

--- a/files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw
+++ b/files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw
@@ -1,0 +1,133 @@
+//--
+// This module demonstrates how to implement a custome `Storage` type.
+//--
+
+pub struct StoragePair<A, B> where A: Storage, B: Storage {
+    self_key: StorageKey,
+}
+
+impl<A, B> Storage for StoragePair<A, B> where A: Storage, B: Storage {
+    type Value = (A::Value, B::Value);
+    type Config = (A::Config, B::Config);
+
+    const fn new(self_key: &StorageKey) -> Self {
+        Self {
+            self_key: *self_key
+        }
+    }
+
+    const fn internal_get_config(self_key: &StorageKey, pair: &(A::Value, B::Value)) -> Self::Config {
+        let first_element_self_key = Self::get_first_element_self_key(self_key);
+        let snd_element_self_key = Self::get_snd_element_self_key(self_key);
+
+        (A::internal_get_config(&first_element_self_key, &pair.0), B::internal_get_config(&snd_element_self_key, &pair.1))
+    }
+
+    const fn internal_layout() -> StorageLayout {
+        use std::storage::StorageLayout::*;
+        match (A::internal_layout(), B::internal_layout()) {
+            // If both sizes are known, we pack the elements one after another
+            // and provide the known overall size.
+            (ContinuousOfKnownSize(a), ContinuousOfKnownSize(b)) => ContinuousOfKnownSize(a + b),
+            // If the first element has a known size, we continue storing the
+            // second element in consecutive remaining words and consecutive slots.
+            (ContinuousOfKnownSize(_), _) => Continuous,
+            _ => Scattered,
+        }
+    }
+
+    const fn self_key(&self) -> StorageKey {
+        self.self_key
+    }
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, pair: &(A::Value, B::Value)) -> Self {
+        let first_element_self_key = Self::get_first_element_self_key(self_key);
+        let snd_element_self_key = Self::get_snd_element_self_key(self_key);
+
+        A::init(&first_element_self_key, &pair.0);
+        B::init(&snd_element_self_key, &pair.1);
+
+        Self::new(self_key)
+    }
+}
+
+impl<A, B> StoragePair<A, B> where A: Storage, B: Storage {
+    /// Returns the self key of the first element of the pair.
+    /// `self_key` is the self key of the [StoragePair].
+    const fn get_first_element_self_key(self_key: &StorageKey) -> StorageKey {
+        // The first element is always stored at the pair self key.
+        *self_key
+    }
+
+    /// Returns the self key of the second element of the pair.
+    /// `self_key` is the self key of the [StoragePair].
+    const fn get_snd_element_self_key(self_key: &StorageKey) -> StorageKey {
+        use std::storage::StorageLayout::*;
+        match (A::internal_layout(), B::internal_layout()) {
+            (ContinuousOfKnownSize(first_size), _) => {
+                //--
+                // The elements are packed and aligned to optimize slot usage and storage access.
+                // Here we calculate the second element storage key based on the size of
+                // the first element.
+                // Note that the calculation will be a const eval one.
+                //--
+                StorageKey::new(<result of the calculation>);
+            },
+            _ => {
+                // The second element is stored in its own slot.
+                StorageKey::new(__sha256((*self_key, 0)), 0);
+            }
+        }
+    }
+
+    #[storage(read)]
+    pub const fn first(&self) -> A {
+        A::new(Self::get_first_element_self_key(&self.self_key))
+    }
+
+    #[storage(read)]
+    pub const fn snd(&self) -> B {
+        B::new(Self::get_snd_element_self_key(&self.self_key))
+    }
+
+    #[storage(write)]
+    pub fn set_first(&mut self, value: &A::Value) -> A {
+        let first_element_self_key = Self::get_first_element_self_key(&self.self_key);
+        A::init(&first_element_self_key, value)
+    }
+
+    #[storage(write)]
+    pub fn set_snd(&mut self, value: &B::Value) -> B {
+        let snd_element_self_key = Self::get_snd_element_self_key(&self.self_key);
+        A::init(&snd_element_self_key, value)
+    }
+
+    /* ... Oher `StoragePair` methods. ... */
+}
+
+impl<A, B> DeepReadStorage for StoragePair<A, B> where A: DeepReadStorage, B: DeepReadStorage {
+    /// Returns the entire content stored within the [StoragePair],
+    /// or `None` if any of the [StoragePair] elements is uninitialized.
+    ///
+    /// This method can result in multiple storage reads and must,
+    /// therefore, be used with caution and only if the entire content
+    /// is actually needed.
+    #[storage(read)]
+    fn try_deep_read(&self) -> Option<Self::Value> {
+        let first_element_self_key = Self::get_first_element_self_key(self_key);
+        let snd_element_self_key = Self::get_snd_element_self_key(self_key);
+
+        let first_element_value = match A::new(first_element_self_key).try_deep_read() {
+            Some(value) => value,
+            None => return None,
+        };
+
+        let snd_element_value = match A::new(snd_element_self_key).try_deep_read() {
+            Some(value) => value,
+            None => return None,
+        };
+
+        Some((first_element_value, snd_element_value))
+    }
+}

--- a/rfcs/0013-configurable-and-composable-storage.md
+++ b/rfcs/0013-configurable-and-composable-storage.md
@@ -1,0 +1,600 @@
+ Name- Feature: `configurable_and_composable_storage`
+- Start Date: 2024-06-10
+- RFC PR: [FuelLabs/sway-rfcs#0000](https://github.com/FuelLabs/sway-rfcs/pull/001)
+- Sway Issue: [FueLabs/sway#0000](https://github.com/FuelLabs/sway/issues/001)
+
+# Summary
+
+[summary]: #summary
+
+This RFC introduces a concept of a `Storage` trait, as well as the `StorageBox` and `StorageEncodedBox` structs. Those types are cornerstones upon which we build a fully flexible, feature rich, and robust access to storage. These concepts simplify defining dynamic storage types, like e.g., `StorageVec`. They also provide a dedicated way of configuring (in the `storage` declaration) and initializing (in the code) arbitrary storage types composed of existing storage types.
+
+Additionally, the RFC provides API design guidelines for storage type's APIs. Those guidelines ensure that various aspects of a storage access like, e.g., accessing uninitialized storage, are alway treated in the same way, across various storage types.
+
+# Motivation
+
+[motivation]: #motivation
+
+The [`storage_keys` RFC](./0008-storage-handler.md) introduced the concept of a `StorageKey` which improved the creation of dynamic storage types, like `StorageVec` and `StorageMap`. While bringing noticeable improvement at the time, that approach, which we currently use, has the following issues and limitations:
+- There is no clear definition of a "storage type", or a "storable type".
+  - E.g., the `x: u64 = 123` syntax only gives a (false) impression that we are storing a `u64` in the storage, while actually just being a syntax sugar for `x: StorageKey<u64> = <compiler-generated configuration of storage slots based on encoded u64>`.
+  - This is especially confusing for dynamic storage types, because they are always, from the Sway perspective, just empty structs. Their real definition is an impl of `StorageKey<T>`. E.g., `StorageVec<V>` becomes `impl<V> StorageKey<StorageVec<V>>`.
+  - Above points lead to confusing error messages when using `storage` and forbid having methods like `clear()` or `read()` on dynamic storage types, because they clash with already existing methods implemented for every `StorageKey`.
+  - Similarly, the common methods, like the mentioned `clear()` and `read()` might not have sense for certain storage types but they are still always available.
+- Composing dynamic storage types, e.g., `StorageVec<StorageVec<u64>>`, relays on the `field_id` hack in the `StorageKey`.
+  - `field_id` represents an unnecessary cognitive burden when using `StorageKey`s.
+  - Proper usage of `filed_id` is error-prone and its false usage, which is easy to happen, can lead to hard-to-explain bugs like, e.g., [this one](https://github.com/FuelLabs/sway/issues/6036F).   
+- Clearing dynamic storage types, e.g., `StorageVec<T>`, relays on a global hack in the `clear()` method of the `StorageKey`.
+- Dynamic storage types cannot be configured in the `storage` declaration.
+  - Those types are always configured as empty Sway structs. E.g., `StorageVec { }`.
+  - Programmers are forced to alway write those empty structs in the configuration, just to satisfy the compiler.
+  - The only way to configure dynamic storage types is via SDKs, or by using them in code, thus at runtime.
+- As a consequence of the above points, but also a separate requirement, it is not possible to write a const eval function that could configure a dynamic storage type based on a certain logic.
+- As a consequence of the above points, but also a separate requirement, it is not possible to configure a dynamic storage type composed of other storage types, like e.g., `StorageMap<u64, StorageVec<u256>>`.
+- Elements in the `storage` declaration must alway be configured, even if programmers just want to list them and actually configure them during deployment via SDKs.
+- It is not possible to store dynamic Sway types like `Vec` and `String` in the storage.
+
+The above points lead to:
+- non-optimal developer experience (e.g., missing possibility to configure dynamic storage types in `storage` declarations; being forced to configure all `storage` elements, etc.).
+- difficult and error-prone development of user-defined dynamic storage types due to error-prone storage access design and storage API.
+- possibility to provide inconsistent APIs (e.g., `StorageVec::pop()` returns `V` while `StorageVec::get()` returns `StorageKey<V>`).
+
+With the approach proposed in this RFC, we will solve all the above points by providing:
+- clear abstractions for storable types via `Storage` trait, as well as storage primitives for storing arbitrary Sway types, even the dynamic ones.
+  - The abstractions will forbid semantically wrong usage by-design.
+- support for safe and arbitrary composable and configurable dynamic storage types.
+  - Implementing the `Storage` trait will automatically make a storage type compatible with all other storage types.
+- support for complex configuration of dynamic storage types in `storage` declarations.
+- support for skipping default configuration of elements in `storage` declarations.
+
+## Sample code
+
+[sample-code]: #sample-code
+
+To prove that such implementation is possible and to give a tangible feeling for the proposed new approach to storage handling, this RFC comes with extensive [sample code](../files/0013-configurable-and-composable-storage/):
+- [sway-libs](../files/0013-configurable-and-composable-storage/sway-libs/) provide:
+  - definition of the `Storage` trait as well as few other traits like, e.g., `DeepReadStorage` and `DeepClearStorage`.
+  - implementation of the atomic `Storage` types, `StorageBox` and `StorageEncodedBox`.
+  - implementation of STD dynamic storage types like, e.g., `StorageVec` and `StorageMap`.
+- [user-defined-libs](../files/0013-configurable-and-composable-storage/user-defined-libs/) provide:
+  - implementation of a user defined `StoragePair` storage type.
+- [contracts](../files/0013-configurable-and-composable-storage/contracts/) provide:
+  - several demo-contracts that demonstrate usage of the new storage.
+- [api-design](../files/0013-configurable-and-composable-storage/api-design/) provides:
+  - implementation of several storage types with the focus on explaining the proposed API design guidelines.
+
+The sample code contains documentation for Sway programmers (using Sway doc-comments `///`), as well as extensive explanations for RFC reviewers (using comments starting with `//--`). Open discussion points are marked with `TODO-DISCUSSION`.
+
+Going through the sample code is highly encouraged.
+
+# Guide-level explanation
+
+[guide-level-explanation]: #guide-level-explanation
+
+This guide-level explanation primarily explains how the new `storage` declaration and `Storage` types will be used by Sway programmers. Explaining writing user-defined `Storage` types was more fitting to the [Reference-level explanation](#reference-level-explanation) and is explained there.
+
+## `storage` declarations and storage types
+
+[storage-declarations-and-storage-types]: #storage-declarations-and-storage-types
+
+The `storage` declaration will get a new operator, `:=`, pronounced _configured with_. The left-hand side (LHS) of the `:=` operator will be the definition of the storage element, as it is now. The right-hand side (RHS) will represent the _configuration_ of that storage element. The configuration is any const eval expression that returns an instance of a type stored by the storage type specified on the LHS.
+
+The type of the LHS storage element must implement the `Storage` trait. This trait denotes a storage type that can be an element of a `storage` declaration. The `Storage` trait is explained in detail in the [The `Storage` trait](#the-storage-trait) chapter of the [Reference-level explanation](#reference-level-explanation).
+
+There are two classes of storage types. _Atomic storage types_ are the leafs of hierarchies of composed storage types. They cannot contain other storage types. _Compound storage types_ are storage types that contain other storage types. Standard library (STD) provides two _atomic storage types_, the [`StorageBox`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_box.sw) and the [`StorageEncodedBox`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_encoded_box.sw), as well as several compound storage types, like e.g., [`StorageVec`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_vec.sw) and [`StorageMap`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_map.sw).
+
+To store Sway types of a known size that does not contain pointers or references, the `StorageBox` is used. To store a Sway type of a dynamic size, that implements `AbiEncode` and `AbiDecode`, the `StorageEncodedBox` is used.
+
+```Sway
+storage {
+    box_1: StorageBox<u64> := 0,
+    box_2: StorageBox<u64> := the_meaning_of_life(),
+
+    box_3: StorageBox<Struct> := Struct::default(),
+    box_4: StorageBox<Struct> := Struct { x: 11, y: false },
+    box_4: StorageBox<Struct> := some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"),
+}
+```
+
+If the `Struct` in the above example would have a dynamic size, to store it we just need to replace `StorageBox` with `StorageEncodedBox`:
+
+```Sway
+struct Struct {
+    vec: Vec<u64>,
+    txt: String,
+}
+
+box_1: StorageEncodedBox<Struct> := Struct::default(),
+box_2: StorageEncodedBox<Struct> := Struct { vec: Vec::from([1, 2, 3]), txt: String::from("text") },
+```
+
+The later usage of `storage` elements is completely the same, regardless if they are stored in the `StorageBox` or `StorageEncodedBox`. The only difference is in the background. The `StorageEncodedBox` encodes and decodes the stored values during reading and writing using the ABI encoding and is thus more gas and storage demanding.
+
+It is possible to arbitrarily compose and configure storage types. As an example, let's consider a `StorageVec<StorageVec<StorageBox<Struct>>>` and an intentionally complex `StorageMap`. Note that the `Struct` _must_ be stored in the `StorageBox`. The `StorageVec`, as well as all other _compound storage types_ can store only other store types.
+
+The `[<content>]` on the RHSs represent instances of _typed slices_. As explained in the [Reference-level explanation](#reference-level-explanation), typed slices are one of the language prerequisites for the new storage.
+
+```Sway
+storage {
+    vec_of_vec_1: StorageVec<StorageVec<StorageBox<Struct>>> := [
+        [],
+        [Struct::default()],
+        [
+            Struct::default(),
+            Struct { x: 11, y: false },
+            some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"),
+        ]
+    ],
+
+    map_01: StorageMap<str[3], StorageVec<StorageMap<u64, StorageVec<StorageBox<Struct>>>>> := [
+        ("abc", [
+            (11, [Struct::default(), Struct { x: 11, y: false }]),
+            (22, []),
+            (33, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc"), Struct::default()]),
+        ]),
+        ("def", [
+            (111, [Struct::default(), Struct { x: 111, y: true }]),
+            (222, [Struct::new_false(222)]),
+            (333, [some_const_fn_that_creates_struct(true, Struct { x: 22, y: true }, "abc")]),
+        ]),
+    ],
+}
+```
+
+A simpler example of a `StorageVec` containing `u64` will look like:
+
+```Sway
+storage {
+    vec_of_val_1: StorageVec<StorageBox<u64>> := [],
+    vec_of_val_2: StorageVec<StorageBox<u64>> := [1, 2, 3, 4, 5],
+}
+```
+
+Configuring compound storage types is automatically supported for all storage types (by implementing `Storage`). Here are a few examples for the user-defined storage type [`StoragePair`](../files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw):
+
+```Sway
+storage {
+    pair_1: StoragePair<StorageBox<u64>, StorageEncodedBox<String>> := (123, String::from("text")),
+    pair_2: StoragePair<StVecOfU64, StVecOfU64> := ([1, 2, 3], [11, 22, 33]),
+
+    vec_of_pairs: StorageVec<StoragePair<StorageBox<Struct>, StVecOfU64>> := [
+        (Struct { x: 0, y: true }, [1, 2, 3]),
+        (Struct::default(), []),
+        (Struct { x: 11, y: false }, [111, 222, 333]),
+    ],
+
+    map_of_pairs: StorageMap<str[3], StoragePair<StorageBox<Struct>, StVecOfU64>> := [
+        ("abc", (Struct { x: 0, y: true }, [1, 2, 3])),
+        ("def", Struct::default(), []),
+        ("ghi", Struct { x: 11, y: false }, [111, 222, 333]),
+    ],
+
+    pair_of_pairs: StoragePair<StPairOfStVecOfU64, StPairOfStVecOfU64> := (
+        ([1, 2, 3], [11, 22, 33]),
+        ([4, 5, 6], [44, 55, 66])
+    )
+}
+```
+
+For more examples of using storage types in storage declarations, see:
+- [`demo_contract_basic_storage.sw`](../files/0013-configurable-and-composable-storage/contracts/demo_contract_basic_storage.sw)
+- [`demo_contract_encoded_storage.sw`](../files/0013-configurable-and-composable-storage/contracts/demo_contract_encoded_storage.sw).
+- [`demo_contract_user_defined_storage.sw`](../files/0013-configurable-and-composable-storage/contracts/demo_contract_user_defined_storage.sw).
+
+## Default `storage` configuration
+
+[default-storage-configuration]: #default-storage-configuration
+
+If developers just want to list the `storage` elements, knowing that they will be configured via SDKs, they can list the elements without providing the _configure with_ operator. The types of the values used to configure the elements must implement the `core::default::Default` trait that will be added to the STD.
+
+```Sway
+storage {
+    built_in:    StorageBox<u64>,                                   // Same as `built_in: StorageBox<u64> := 0`.
+    some_struct: StorageBox<Struct>,                                // `Struct` implements `core::default::Default`.
+    storage_vec: StorageVec<StorageBox<u64>>,                       // Slices implement `Default` and the default is an empty slice `[]`.
+    storage_map: StorageMap<str[3], StorageVec<StorageBox<u64>>>,   // Slices implement `Default` and the default is an empty slice `[]`.
+}
+```
+
+## Using storage types in code
+
+[using-storage-types-in-code]: #using-storage-types-in-code
+
+All storage types will be implementing `Storage::new()` and `Storage::init()` constructors that will create an uninitialized and initialized instance of a storage type, respectively. In addition, they will follow the storage API guidelines explained in the [Storage API guidelines](#storage-api-guidelines).
+
+`Storage` constructors and the atomic `StorageBox` and `StorageEncodedBox` will eliminate the need for using the low-level storage API in the contract code. The low-level API will be needed only when implementing custom storage, and even then, its usage will follow simple, well established patterns.
+
+Storage API guidelines will provide unified developer experience across all storage types. Below are a few examples of using storage types in code.
+
+An important term to establish will be the _self key_. Self key is the [`StorageKey`](../files/0013-configurable-and-composable-storage/sway-libs/storage.sw) at which an instance of a storage type is stored.
+
+```Sway
+fn demo() {
+    // Obtain the self key of the locally created `StorageBox`.
+    let local_box_self_key = get_storage_key();
+
+    // `init` will create the `StorageBox` instance and initialize the storage to the `b256::zero()`.
+    let local_box = StorageBox::<b256>::init(local_box_self_key, &b256::zero());
+
+    // `read` reads the stored value or reverts if the `StorageBox` is uninitialized.
+    assert_eq(local_box.read(), 0x0000000000000000000000000000000000000000000000000000000000000000);
+}
+```
+
+When writing to the storage, developers will always write the _value_ that the particular storage expects, and not the storage contained in the storage, thus preventing by-design a wrong, error-prone usage that is possible with the current API. In other words, the API conveys the semantics of composition and containment of storage type hierarchies, which also implies ownership. If a storage is contained in another storage, it cannot at the same time be contained in some other storage.
+
+```Sway
+fn demo() {
+    let mut local_vec_of_vec_of_vec_1 = StorageVec<StorageVec<StorageVec<StorageBox<u64>>>>::init(self_key, &[
+        [],
+        [[]],
+        [[], []],
+        [[11, 22, 33], [33, 22, 11]]
+    ]);
+
+    // The overall Storage API prohibits semantically wrong usage.
+    // The desired composition semantics that implies ownership of the
+    // stored data is imposed by the API.
+    //
+    // E.g., `StorageVec::push` does not accept the contained storage
+    // as the type but rather the value that needs to be contained.
+    //
+    // This prohibits error-prone usage like:
+    //
+    // let vec_of_vec_a = StorageVec<StorageVec<StorageBox<u6>>>::init(...);
+    // let vec_of_vec_b = StorageVec<StorageVec<StorageBox<u6>>>::init(...);
+    // let element_of_a = a.get(0);
+    // vec_of_vec_of_b.push(element_of_a);
+    //
+    // `StorageVec` which is contained in `a` cannot be contained in `b`!
+
+    // In the proposed API, storing in the storage means providing the _value_ to be stored.
+    local_vec_of_vec_of_vec_1.push(&[[11, 22, 33], [33, 22, 11]]);
+}
+```
+
+Storage types will also implement some common storage traits like `DeepReadStorage` and `DeepClearStorage` defined in [`storage.sw`](../files/0013-configurable-and-composable-storage/sway-libs/storage.sw). This will increase the uniformity of use even more. E.g., the `DeepReadStorage` will be implemented by storage types that are fully aware of all the content they store and can read their entire content in one, presumably optimized go.
+
+E.g., the `StorageVec` implements `DeepReadStorage`. So, to get the whole content of, e.g., a `StorageVec<StorageVec<StorageBox<u64>>>` will look like:
+
+```Sway
+// `deep_read` returns the same type that `init` accepts, the type contained and specified by the `Storage` implementation.
+let value = storage.vec_of_vec_of_u64.deep_read();
+
+// In this case that type is a slice of slices of `u64`.
+assert_eq(value, [[1, 2, 3], [11, 22, 33]]);
+```
+
+For more examples on using storage types in code, see the `demo` functions in the [demo contracts](../files/0013-configurable-and-composable-storage/contracts/).
+
+## Storage API design guidelines
+
+[storage-api-design-guidelines]: #storage-api-design-guidelines
+
+Storage API design guidelines are discussed and explained in detail in sample implementations given in the [`api-design`](../files/0013-configurable-and-composable-storage/api-design/). Here we are listing the major decisions and why they make the usage of the API easier by clearly communicating potential nuances in the usage of a particular storage type.
+
+1. The API clearly communicates that the underlying storage might be uninitialized which can cause certain operations, like e.g. `StorageBox::read()` to fail. _All_ operations that can fail must have the `try_` prefix and return an `Option`.
+1. Every `try_` operation has its "non-try" counterpart that returns the value and reverts if the operation fails internally. The counterpart is always named the same as the `try_`, but without the `try_` prefix. E.g., `read()` for `try_read()`.
+1. Uninitialized storage instances are always safe to use. This way we benefit of the possibility to not pay for default initialization and still safely use the storage instance. Every storage type will provide its own semantics for uninitialized storage state. E.g. an uninitialized [`StorageVec`](../files/0013-configurable-and-composable-storage/api-design/storage_vec.sw) has the same semantics as an empty `StorageVec`.
+1. Thus, the failing of `try_` methods can always be seen as a semantic failure. E.g., `StorageVec::try_get()` can fail if the `StorageVec` is not initialized or because it requested element index is out of bounds. Since in the first case we consider the vector to be empty, it is also a semantic error.
+1. Certain operations might have a version with a "special behavior". E.g., in the case of the `StorageVec`, we want to provide a possibility to `get()` an element without the expensive length check. In such cases, the method will be named by the original name, and the suffix indicating the "special behavior". E.g., `StorageVec::get_unchecked()`.
+1. When the special behavior consists of doing deep clear via `DeepClearStorage` or deep read via `DeepReadStorage`, the suffix will always be `_deep_clear` and `_deep_read`, respectively.
+
+Thus, every storage type operation might come in all or some of these flavours:
+- `fn <operation>() -> T`: reverts in case of uninitialized storage or other error.
+- `fn try_<operation>() -> Option<T>`
+- `fn <operation>_<special_behavior>() -> T`: reverts in case of uninitialized storage or other error.
+- `fn try_<operation>_<special_behavior>() -> Option<T>`
+
+This might look like cluttering of a single operation, but:
+1. it properly communicates the behavior of the operation.
+1. having an operation actually implementing all four variants will be rare.
+
+For real-life examples, and the proof of the second point, consider the sample implementations provided in the [`api-design`](../files/0013-configurable-and-composable-storage/api-design/).
+
+## Storage references
+
+[storage-references]: #storage-references
+
+Sometimes we want to be able to store in the storage a "reference" to another storage instance. Storage API and the compiler will provide support for such use cases. On the API level, the `StorageRef` type (defined in the [`storage.sw`](../files/0013-configurable-and-composable-storage/sway-libs/storage.sw)) will contain a type-safe "reference" to a storage element. This "reference" will internally just be the `StorageKey` of the referenced storage element.
+
+```Sway
+pub enum StorageRef<TStorage> where TStorage: Storage {
+    Null: (),
+    Ref: StorageKey,
+}
+```
+
+`StorageRef`s will be stored in [`StorageRefBox`es](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_ref_box.sw) and once retrieved from the storage it will be possible to dereference them to access the referenced storage.
+
+Every storage type automatically provides the `StorageRef` that references it, via the `Storage::as_ref` method.
+
+Thus, storage references provide a convenient, type-safe way to express referencing storage elements, but with a price that might be considerable in some cases. Namely, the `StorageRef` requires two storage slots to store a reference. This means that developers might consider other, less storage consuming, manual approaches to "reference" a storage entity. E.g., if referenced elements are stored in a `StorageVec`, "referencing" them by storing their vector indices as "references" might be less storage-costly. In this case, we are trading type-safety and clear built-in API for the performance.
+
+Storage reference will be supported in the `storage` declarations, by allowing the `storage` keyword to be used on the RHS of the _configure with_ operator:
+
+```Sway
+type StVecOfU64 = StorageVec<StorageBox<u64>>;
+type StPairOfStVecOfU64 = StoragePair<StVecOfU64, StVecOfU64>;
+
+storage {
+    vec_1: StVecOfU64 := [11, 22, 33],
+    vec_2: StVecOfU64 := [44, 55, 66],
+
+    pair_1: StPairOfStVecOfU64 := ([0, 0, 0], [1, 1, 1]),
+    pair_2: StPairOfStVecOfU64 := ([], []),
+
+    map_1: StorageMap<str[3], StVecOfU64> := [
+        ("abc", [1, 2, 3]),
+        ("def", [11, 22, 33]),
+        ("ghi", [111, 222, 333]),
+    ]
+
+    //--
+    // Storage references can be used in storage configurations.
+    // They can reference other storage elements, or their parts.
+    //--
+    vec_of_refs: StorageVec<StorageRefBox<StVecOfU64>> := [
+        StorageRef::Null,
+        storage.vec_1.as_ref(), // <<-- Note using the `storage` keyword here, as well as `as_ref`.
+        storage.pair_1.first().as_ref(),
+        storage.map_1.get("abc").as_ref(),
+        StorageRef::Ref(some_const_fn_that_returns_the_storage_key_of_the_referenced_storage()),
+    ],
+}
+```
+
+For more examples on using storage references, see the [`demo_contract_storage_references.sw`](../files/0013-configurable-and-composable-storage/contracts/demo_contract_storage_references.sw).
+
+## Breaking changes
+
+[breaking-changes]: #breaking-changes
+
+This proposal brings breaking changes in:
+- `storage` declarations.
+- existing STD storage types like, e.g., `StorageVec`.
+- low-level storage API.
+- the code that deals with the storage, via any of the above approaches.
+
+Additionally, values stored using the current storage API cannot always be read with the new API and vice versa, because some of the changes will result in a different layout of the stored values within the storage.
+
+To support explaining breaking changes to existing users and to ease migration we will:
+- utilize [expressive diagnostics](./0012-expressive-diagnostics.md) to provide detailed explanations on how to fix compiler errors and migrate the code.
+- where applicable, provide scripts to semi-automate the migration by converting the existing code to the new syntax and semantics.
+
+# Reference-level explanation
+
+[reference-level-explanation]: #reference-level-explanation
+
+The implementation of the proposed features relies on a couple of other language features that need to be implemented first. We will only list them here, since their detailed explanation, in certain cases, could require a separate RFC. To follow the reference-level explanation of the configurable and composable storage, it is sufficient to have an intuitive understanding of these language features. Where needed, they are explained in enough detail in the [sample code](../files/0013-configurable-and-composable-storage/).
+
+The [sample code](../files/0013-configurable-and-composable-storage/) provides a detailed view on how the Sway STD part of this RFC will be implemented and used.
+
+Here, we will focus on the compiler support for the feature.
+
+The additional language features that are the prerequisite to implement this RFC are:
+- const functions and traits.
+- typed slices.
+- marker traits.
+- negative impls.
+- type aliases with generic parameters and trait constraints.
+
+## The `Storage` trait
+
+[the-storage-trait]: #the-storage-trait
+
+The `Storage` trait is [defined](../files/0013-configurable-and-composable-storage/sway-libs/storage.sw) as:
+
+```Sway
+pub trait Storage {
+    type Value;
+    type Config;
+
+    const fn new(self_key: &StorageKey) -> Self;
+
+    const fn internal_get_config(self_key: &StorageKey, value: &Self::Value) -> Self::Config;
+
+    const fn internal_layout() -> StorageLayout;
+
+    const fn self_key(&self) -> StorageKey;
+
+    #[storage(write)]
+    fn init(self_key: &StorageKey, value: &Self::Value) -> Self;
+} {
+    const fn as_ref(&self) -> StorageRef<Self> {
+        StorageRef::<Self>::Ref(self.self_key())
+    }
+}
+```
+
+The functions prefixed with `internal` are used only when implementing storage types, and should never be used in contract code.
+
+`Storage` trait methods and associated types provide all the information needed by the compiler to:
+- support configuring arbitrary storage types in `storage` declarations.
+- support type-checking arbitrary composition of storage types.
+
+The get a hands-on feeling for concrete implementations of the `Storage` trait and better understanding of the meaning of its methods and associated types see the [provided implementations of STD storage types](../files/0013-configurable-and-composable-storage/sway-libs/storage/) and the user-defined [`StoragePair`](../files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw).
+
+Let's explain the `Storage` type by explaining how it is used by the compiler and when implementing storage types.
+
+### Configuring storage
+
+[configuring-storage]: #configuring-storage
+
+The `Value` associated type specifies the type of the _entire_ value that is stored in the storage. Compiler expect the RHS of the _configure with_ operator to be of this type.
+
+E.g., the `StorageBox<T>` stores values of type `T` which means it will define its `Value` as `type Value = T`.
+
+Arbitrary composition of storage types is made simple by intuitive recursive definitions of `Value` associated types.
+
+E.g., the `StorageVec<TStorage>` (note here that every _compound storage type_ can store only types that implement `Storage`) will store slices of whatever the value of the contained `TStorage` is. Thus, its `Value` will simply be `type Value = [TStorage::Value]`.
+
+Similarly, the `StorageMap` will store `(K, V)` tuples, where `V` must be `Storage`. Thus, its `Value` will simply be `type Value = (K, V::Value)`.
+
+Once the `Value` is specified in the `Storage` implementation the compiler can type-check the RHS of `:=` against the `Value` expected by the LHS. It is worth noticing here that we have all the information needed, to, in a case of a type-mismatch, provide a detailed [expressive diagnostics](./0012-expressive-diagnostics.md) explaining the error.
+
+Also, every storage type will always have the same way of configuring, defined by the `Value` type. This guarantees intuitive and consistent usage. E.g., for the `StorageVec`, developers will know that they always need to provide a slice of the values expected by the contained storage type.
+
+The provided RHS expression that returns the type specified by `Value` must be const eval, as it is now.
+
+In the second step, the compiler needs to calculate the concrete storage slots in which to store the _configured with_ RHS values.
+
+This is where the `Storage::Config` associated type comes in play, together with the `const fn` function `internal_get_config()`.
+
+Before generating the slots, the compiler already knows:
+- the `StorageKey` at which a particular `storage` element will be stored. This key is calculated based on the element name and namespace, or it is given using the `in` keyword. This storage key is, as mentioned below, called the _self key_ of the storage element.
+- the const eval calculated RHS which has the type `Value`.
+
+The `const fn internal_get_config()` takes exactly those two parameters and provides a result of type `Self::Config`. Every `Self::Config` type is a combination of `StorageConfig` types defined as:
+
+```Sway
+pub struct StorageConfig<TValue>
+{
+    pub storage_key: StorageKey,
+    pub value: TValue,
+}
+```
+
+Essentially, the `StorageConfig<TValue>` tells the compiler at which `storage_key` the `value` should be stored. This information is const calculated by every storage type.
+
+E.g., the `StorageBox<T>` simply stores a value of the type `T` at its `self_key`. Therefore, its `Config` will be defined as `type Config = StorageConfig<T>`.
+
+E.g., the `StorageVec<TStorage>` must be able to store the vector's length and the configuration of all the contained elements. Thus, its `Config` can be specified as `type Config = (StorageConfig<u64>, [TStorage::Config])`. The first part of the tuple is the length, and the second the slice of all the `Config`s of the contained storage type.
+
+In general, the `Config` type is defined recursively as:
+
+```
+<Config> := StorageConfig<TValue>
+            | [<Config>]
+            | (<Config>, ...);
+```
+
+Where `[<Config>]` represents a slice of `Config`s and `(<Config>, ...)` a tuple of arbitrary many `Config`s.
+
+During the evaluation of storage slots, the compiler will traverse the structure returned by the `internal_get_config()` and for every occurrence of `StorageConfig<TValue>` it will create the corresponding slot definition.
+
+Note that the constraints set on _atomic storage types_ will ensure that the `TValue` is of a type that compiler can serialize to slots.
+
+### Using `storage` in code
+
+[using-storage-in-code]: #using-storage-in-code
+
+When a `storage` element is accessed in code via, e.g., `storage::ns1::ns2.elem`, the compiler will calculate the _self key_ of the element (`elem` in this example) and call the `Storage::new()` implementation of its storage type to create an instance. The `new` will get the calculated _self_key_ as the parameter.
+
+Notice here that a `storage` element is always guaranteed to be a type that implements `Storage`. Having a non-`Storage` type in a `storage` declaration is a compile error. E.g, this is not allowed:
+
+```Sway
+storage {
+    x: u64 := 0, // ERROR: `u64` does not implement `Storage`.
+}
+```
+
+### Optimizing storage layout
+
+[optimizing-storage-layout]: #optimizing-storage-layout
+
+The `Storage::internal_layout()` function returns an instance of the `StorageLayout` enum defined as:
+
+```Sway
+/// Defines how a concrete [Storage] implementation places
+/// its stored values within the storage, relative to the
+/// given self key of the storage.
+pub enum StorageLayout {
+    /// The values are scattered within the storage and
+    /// can be on arbitrary storage slots, unrelated to
+    /// the self key.
+    Scattered: (),
+    /// The values are stored starting from the self key
+    /// in a continuous sequence of consecutive storage
+    /// slots. The size that the stored value occupies is
+    /// not know and can vary.
+    Continuous: (),
+    /// The values are stored starting from the self key
+    /// in a continuous sequence of consecutive storage
+    /// slots. The size that the stored value occupies is
+    /// known and fixed.
+    ContinuousOfKnownSize: u64,
+}
+```
+
+This way, a storage type, when embedded within another storage can signal to its "parent" to optimize storing of its child elements by e.g., packing them.
+
+E.g., the `StorageVec<TStorage>` will use this information to pack its elements in consecutive slots if the `TStorage` is, e.g., `StorageBox<Struct>` whose layout is the fixed `ContinuousOfKnownSize(__size_of(Struct))`. To see how the `internal_layout` function is used in the implementation of the `StorageVec` see [`storage_vec.sw`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_vec.sw).
+
+E.g., the user-defined `StoragePair<A, B>` also uses this information to provide optimal storage use, as shown in the [`storage_pair.sw`](../files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw).
+
+### Developing storage types
+
+[developing-storage-types]: #developing-storage-types
+
+With the `Storage` trait defined as such, developing arbitrary storage types becomes straightforward. Every storage type is to be seen as a recursive container of other storage types, where we know that this "recursion" must end with some of the _atomic storage types_.
+
+Thus, the implementations of storage types are essentially recursive compositions of their contained storage types. The `Value` and the `Config` associated types will, in general, be constructed based on the `Value` and `Config` types of the contained storage types. Similarly, the implementations of the `internal_get_config()` and `init()` functions will recursively call those same methods of the contained storage types.
+
+To get the feeling for these straightforward and essentially short and compact implementations of storage types, see the atomic and compound storage types implemented in [`sway-libs`](../files/0013-configurable-and-composable-storage/sway-libs/) and the user-defined [`StoragePair`](../files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw).
+
+### Defining storage traits
+
+[defining-storage-traits]: #defining-storage-traits
+
+The clear definition of the `Storage` trait allows defining storage traits. A storage trait is a trait that has `Storage` as a supertrait. The STD will come with (at least) two storage traits, `DeepReadStorage` and `DeepClearStorage` both defined in the [`storage.sw`](../files/0013-configurable-and-composable-storage/sway-libs/storage.sw).
+
+The implementations of storage traits will, similar to the implementations of `Storage`, be straightforward and based on recursive calls to the implementations of the same storage traits on the contained storage types.
+
+To get the feeling for these straightforward and essentially short and compact implementations of storage traits, see the implementations of `DeepReadStorage` and `DeepClearStorage` for [`StorageVec`](../files/0013-configurable-and-composable-storage/sway-libs/storage/storage_vec.sw) and [`StoragePair`](../files/0013-configurable-and-composable-storage/user-defined-libs/storage_pair.sw).
+
+By convention, all storage trait will have the suffix `Storage`.
+
+## Internal API and the `__state` intrinsics
+
+[internal-api-and-the-state-intrinsics]: #internal-api-and-the-state-intrinsics
+
+The STD will still provide the low-level storage `read`, `write`, and `clear` functions. However, unlike now when they are actually sometimes needed in contract code, e.g., to store arrays, in the new storage implementation there should never be a need to use them in contracts. Instead, the atomic `StorageBox` and `StorageEncodedBox` should be used. They provide the same low-level functionality while offering safe storage access.
+
+The low-level API will be used only when implementing storage types, and even in those cases not always. Thus, the proposal is to move them to the module named [`internal`](../files/0013-configurable-and-composable-storage/sway-libs/storage/internal.sw) to emphasize that they are, similar to `Storage::internal_` functions, meant to be used only when developing custom storage types.
+
+Similarly, the `__state_` intrinsics should be used only in the implementations of the internal API functions. In addition, the `__state_load_word` intrinsic should be changed to return the information if the requested slot was set or unset.
+
+# Drawbacks
+
+[drawbacks]: #drawbacks
+
+The only drawback I can think of is the time and effort needed to implement the proposal and to deal with the [breaking changes](#breaking-changes). However, the impact of _not_ improving the current storage handling will over time surely be higher. It would mean carrying on the issues mentioned in the [Motivation](#motivation) and, worst of all, living with an API that is error-prone by-design.
+
+# Rationale and alternatives
+
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+During the work on this RFC, five different approaches were intensely discussed and modeled in code. Non of them came even near to the simplicity of use and implementation of the proposed approach. Also, all of the discussed approaches could not guarantee an API that would prevent error-prone implementation of storage types, when it comes to the containment and composition semantics.
+
+For the storage API design guidelines, three different approaches were considered. We've tried to, e.g.:
+- additionally distinguish between operations failing because of the storage being uninitialized and because of semantic errors like out of bound access. 
+- avoid having possible multiple versions of a method by, e.g., putting the `Storage` instance in a "state" where it behaves differently for particular operations.
+
+All three approaches ended up to be less intuitive to use and implement then the approach proposed in the [Storage API design guidelines](#storage-api-design-guidelines).
+
+# Prior art
+
+[prior-art]: #prior-art
+
+As the [`storage_keys` RFC](./0008-storage-handler.md) puts it, there is no much prior art that would correspond with the overall direction for storage handling that we took in Sway. This means, having the `storage` elements be distinguished and having the API that communicates that storage operations might fail.
+
+The proposed approach builds on top of those two premisses, and brings robust and easy to implement composable storage types that can be arbitrarily configured in `storage` declarations.
+
+# Unresolved questions
+
+[unresolved-questions]: #unresolved-questions
+
+Through the RFC process I expect the following open questions to be resolved:
+- questions posed in the [sample code](../files/0013-configurable-and-composable-storage/) and marked with `TODO-DISCUSSION`.
+- naming of proposed code elements like, e.g., method/function names, type names, etc. Since those names will become the part of the storage API it is of highest importance to come up with good and expressive names for abstractions.
+
+Also, I expect the current storage attributes, `#[storage(read, write)]`, to be discussed. In the sample code, the existing attributes are used. However, there are two questions to be decided on:
+- if the meaning of `write` remains "read and write" as it is now, the attributes should be renamed to `readonly` and `readwrite`.
+- if we want to strictly distinguish between `read` and `write`, the question is why not introduce `clear` as well, which is currently treated as `write`.
+
+# Future possibilities
+
+[future-possibilities]: #future-possibilities
+
+As already mentioned in the [`storage_keys` RFC](./0008-storage-handler.md), if we ever introduce the `Index` trait, it can also be implemented for the storage types like, e.g., `StorageVec`.


### PR DESCRIPTION
[Rendered](https://github.com/FuelLabs/sway-rfcs/blob/ironcev/storage-v3/rfcs/0013-configurable-and-composable-storage.md)

This RFC introduces a concept of a `Storage` trait, as well as the `StorageBox` and `StorageEncodedBox` structs. Those types are cornerstones upon which we build a fully flexible, feature rich, and robust access to storage. These concepts simplify defining dynamic storage types, like e.g., `StorageVec`. They also provide a dedicated way of configuring (in the `storage` declaration) and initializing (in the code) arbitrary storage types composed of existing storage types.

Additionally, the RFC provides API design guidelines for storage type's APIs. Those guidelines ensure that various aspects of a storage access like, e.g., accessing uninitialized storage, are alway treated in the same way, across various storage types.